### PR TITLE
fix: Add config to generate ingress in chart into deployment

### DIFF
--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -58,34 +58,26 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ .Values.name }}
-  labels:
-    app: {{ .Values.name }}
-{{- with .Values.ingress.annotations }}
+  name: public-{{ .Values.name }}
+  namespace: {{ .Release.Namespace }}
   annotations:
-{{ toYaml . | indent 4 }}
-{{- end }}
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/enable-cors: "{{ .Values.ingress.public.enableCors | default "true" }}"
 spec:
-{{- if .Values.ingress.className }}
-  ingressClassName: {{ .Values.ingress.className }}
-{{- end }}
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - {{ tpl .Values.ingress.host . }}
+      secretName: {{ tpl .Values.ingress.tlsSecret . }}
   rules:
-{{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ tpl .Values.ingress.host . }}
       http:
         paths:
-{{- range .paths }}
-          - path: {{ .path }}
-            pathType: {{ .pathType }}
+          - path: /
+            pathType: Prefix
             backend:
               service:
-                name: {{ $.Values.name }}
-                port:
-                  number: {{ $.Values.service.port }}
-{{- end }}
-{{- end }}
-{{- if .Values.ingress.tls }}
-  tls:
-{{ toYaml .Values.ingress.tls | indent 4 }}
-{{- end }}
+                 name: {{ .Values.name }}
+                 port:
+                   number: {{ .Values.service.port }}
 {{- end }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -1,5 +1,10 @@
+# Global configuration for the application
+global: 
+  domain: testnet.verana.network 
+
 # General configuration
 name: verana-frontend
+host: app
 replicas: 1
 
 # Image configuration
@@ -43,12 +48,13 @@ resources: {}
 
 # Optional ingress configuration
 ingress:
-  enabled: false
-  className: ""
-  annotations: {}
-  hosts:
-    - host: ""
-      paths:
-        - path: /
-          pathType: Prefix
-  tls: []
+  enabled: true
+  host: "{{ .Values.host }}.{{ .Values.global.domain }}"
+  tlsSecret: public.{{ .Values.host }}.{{ .Values.global.domain }}-cert
+  public:
+    enableCors: true
+  private:
+    enableCors: true
+    whitelistSourceRange: "" # e.g. "xxx.xx.xxx.xxx/32"
+    tlsSecret: "private.{{ .Values.host }}.{{ .Values.global.domain }}-cert"
+    host: ""


### PR DESCRIPTION
This PR adds the Ingress configuration to the application chart for app.testnet.verana.network (dev version).