### PR TITLE
fix: resolve ETXTBSY error and pod memory pressure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,10 +28,8 @@ COPY --from=deps /app/node_modules ./node_modules
 # Copy source code
 COPY . .
 
-# Set build-time environment variables (placeholders for runtime substitution)
+# Set build-time environment variables
 ENV NODE_ENV=production
-ENV NEXT_PUBLIC_PORT=APP_NEXT_PUBLIC_PORT
-ENV NEXT_PUBLIC_BASE_URL=APP_NEXT_PUBLIC_BASE_URL
 
 # Build the application (standalone output configured in next.config.ts)
 RUN yarn build
@@ -68,6 +66,8 @@ EXPOSE 3000
 
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
+# Limit Node.js memory to prevent OOM kills in constrained environments
+ENV NODE_OPTIONS="--max-old-space-size=512"
 
 ENTRYPOINT ["/app/entrypoint.sh"]
 CMD ["node", "server.js"]

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -44,7 +44,13 @@ env:
 extraEnv: []
 
 # Resource requests/limits for the frontend container
-resources: {}
+resources:
+  requests:
+    memory: "512Mi"
+    cpu: "250m"
+  limits:
+    memory: "1Gi"
+    cpu: "500m"
 
 # Optional ingress configuration
 ingress:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,35 @@
 #!/bin/sh
+set -e
 
-find /app/.next \( -type d -name .git -prune \) -o -type f -print0 | xargs -0 sed -i "s#APP_NEXT_PUBLIC_PORT#$NEXT_PUBLIC_PORT#g"
-find /app/.next \( -type d -name .git -prune \) -o -type f -print0 | xargs -0 sed -i "s#APP_NEXT_PUBLIC_BASE_URL#$NEXT_PUBLIC_BASE_URL#g"
+# Runtime environment variables are handled by next-runtime-env
+# No file modification needed - NEXT_PUBLIC_* vars are read at runtime
+# See: https://github.com/expatfile/next-runtime-env
 
-echo "Starting Nextjs"
+# Validate required environment variables
+REQUIRED_VARS="
+NEXT_PUBLIC_VERANA_CHAIN_ID
+NEXT_PUBLIC_VERANA_CHAIN_NAME
+NEXT_PUBLIC_VERANA_RPC_ENDPOINT
+NEXT_PUBLIC_VERANA_REST_ENDPOINT
+"
+
+echo "Validating environment variables..."
+missing_vars=""
+
+for var in $REQUIRED_VARS; do
+    val=$(eval echo "\$$var")
+    if [ -z "$val" ]; then
+        missing_vars="$missing_vars $var"
+        echo "ERROR: Missing required environment variable: $var"
+    fi
+done
+
+if [ -n "$missing_vars" ]; then
+    echo "FATAL: Required environment variables are missing:$missing_vars"
+    echo "Please configure these variables in your Kubernetes deployment."
+    exit 1
+fi
+
+echo "Environment validation passed"
+echo "Starting Next.js"
 exec "$@"

--- a/kubernetes/verana-frontend-deployment.yaml
+++ b/kubernetes/verana-frontend-deployment.yaml
@@ -49,3 +49,10 @@ spec:
           value: "${NEXT_PUBLIC_SESSION_LIFETIME_SECONDS}"
         ports:
         - containerPort: 3000
+        resources:
+          requests:
+            memory: "512Mi"
+            cpu: "250m"
+          limits:
+            memory: "1Gi"
+            cpu: "500m"


### PR DESCRIPTION
## Summary

This PR fixes the critical production issue causing repeated pod evictions and 503 errors on the testnet frontend.

### Problem
- Pods repeatedly evicted due to **MemoryPressure** on node `cluster-utc-node-07efe5`
- **ETXTBSY error**: `text file is busy, open '/tmp/next-server'`
- Only 1 of 6 pods running at a time, causing intermittent 503 errors

### Root Cause Analysis

1. **ETXTBSY Error**: `entrypoint.sh` used `sed -i` to modify files in `.next/` directory at container startup. This conflicted with Node.js trying to read those same files, causing file lock errors.

2. **Memory Pressure**: No Kubernetes resource limits were defined, allowing pods to consume unlimited memory until the node hit pressure and evicted them.

3. **No Heap Limit**: Node.js had no memory cap, allowing the heap to grow unbounded.

### Solution

| Change | File | Description |
|--------|------|-------------|
| Remove sed hack | `entrypoint.sh` | The app already uses `next-runtime-env` for runtime env vars |
| Add env validation | `entrypoint.sh` | Fail fast with clear errors if required vars are missing |
| Add NODE_OPTIONS | `Dockerfile` | Cap Node.js heap at 512MB |
| Add resource limits | `charts/values.yaml` | 512Mi request / 1Gi limit |
| Add resource limits | `kubernetes/verana-frontend-deployment.yaml` | Same limits for standalone deployments |

### Testing

- [x] Verified `next-runtime-env` is properly configured (`PublicEnvScript` in layout.tsx)
- [x] Verified no app code references `NEXT_PUBLIC_PORT` or `NEXT_PUBLIC_BASE_URL` (the sed targets)
- [x] YAML syntax validated
- [x] Shell script syntax validated
- [x] Code reviewed by multiple agents

### Test Plan

1. Deploy to staging/testnet
2. Verify pods start successfully with env validation message in logs
3. Monitor memory usage stays within limits
4. Verify no ETXTBSY errors in logs
5. Confirm all NEXT_PUBLIC_* env vars are accessible in the browser