### PR TITLE
fix: add betanet deployment with memory limits

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -109,11 +109,22 @@ jobs:
         if: steps.semantic.outputs.new-release-published == 'true'
         uses: azure/setup-helm@v3
 
-      - name: Deploy (Helm upgrade --install)
+      - name: Deploy to testnet (Helm upgrade --install)
         if: steps.semantic.outputs.new-release-published == 'true'
         run: |
           helm upgrade --install verana-frontend ./charts \
             -n vna-testnet-1 \
+            --create-namespace \
+            --wait \
+            --atomic \
+            --timeout 20m
+
+      - name: Deploy to betanet (Helm upgrade --install)
+        if: steps.semantic.outputs.new-release-published == 'true'
+        run: |
+          helm upgrade --install verana-frontend ./charts \
+            -f ./charts/values-betanet.yaml \
+            -n vna-betanet-1 \
             --create-namespace \
             --wait \
             --atomic \

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -1,0 +1,59 @@
+name: Manual Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Target environment'
+        required: true
+        default: 'testnet'
+        type: choice
+        options:
+          - testnet
+          - betanet
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+        with:
+          version: "latest"
+
+      - uses: azure/k8s-set-context@v4
+        with:
+          method: kubeconfig
+          kubeconfig: ${{ secrets.OVH_KUBECONFIG }}
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+
+      - name: Set deployment variables
+        id: vars
+        run: |
+          if [ "${{ inputs.environment }}" = "betanet" ]; then
+            echo "namespace=vna-betanet-1" >> $GITHUB_OUTPUT
+            echo "values_file=./charts/values-betanet.yaml" >> $GITHUB_OUTPUT
+          else
+            echo "namespace=vna-testnet-1" >> $GITHUB_OUTPUT
+            echo "values_file=./charts/values.yaml" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Deploy (Helm upgrade --install)
+        env:
+          NAMESPACE: ${{ steps.vars.outputs.namespace }}
+          VALUES_FILE: ${{ steps.vars.outputs.values_file }}
+        run: |
+          helm upgrade --install verana-frontend ./charts \
+            -f "$VALUES_FILE" \
+            -n "$NAMESPACE" \
+            --create-namespace \
+            --wait \
+            --atomic \
+            --timeout 20m

--- a/charts/values-betanet.yaml
+++ b/charts/values-betanet.yaml
@@ -1,0 +1,66 @@
+# Betanet configuration for the application
+global:
+  domain: betanet.verana.network
+
+# General configuration
+name: verana-frontend
+host: app
+replicas: 1
+
+# Image configuration
+image:
+  repository: veranalabs/verana-front
+  tag: dev
+  pullPolicy: IfNotPresent
+
+# Service configuration
+service:
+  type: ClusterIP
+  port: 3000
+  targetPort: 3000
+
+# Node scheduling preferences
+nodeSelector:
+  kubernetes.io/hostname: cluster-utc-node-07efe5
+
+# Environment variables consumed by the application
+env:
+  NEXT_PUBLIC_PORT: "3000"
+  NEXT_PUBLIC_BASE_URL: "http://localhost:3000"
+  NEXT_PUBLIC_VERANA_CHAIN_ID: "vna-betanet-1"
+  NEXT_PUBLIC_VERANA_CHAIN_NAME: "VeranaBetanet1"
+  NEXT_PUBLIC_VERANA_RPC_ENDPOINT: "https://rpc.betanet.verana.network"
+  NEXT_PUBLIC_VERANA_REST_ENDPOINT: "https://api.betanet.verana.network"
+  NEXT_PUBLIC_VERANA_REST_ENDPOINT_TRUST_DEPOSIT: "https://idx.betanet.verana.network/verana/td/v1"
+  NEXT_PUBLIC_VERANA_REST_ENDPOINT_DID: "https://idx.betanet.verana.network/verana/dd/v1"
+  NEXT_PUBLIC_VERANA_REST_ENDPOINT_TRUST_REGISTRY: "https://idx.betanet.verana.network/verana/tr/v1"
+  NEXT_PUBLIC_VERANA_REST_ENDPOINT_CREDENTIAL_SCHEMA: "https://idx.betanet.verana.network/verana/cs/v1"
+  NEXT_PUBLIC_VERANA_REST_ENDPOINT_PERM: "https://idx.betanet.verana.network/verana/perm/v1"
+  NEXT_PUBLIC_VERANA_TOPUP_VS: "did:web:faucet-vs.betanet.verana.network"
+  NEXT_PUBLIC_VERANA_SIGN_DIRECT_MODE: "false"
+  NEXT_PUBLIC_SESSION_LIFETIME_SECONDS: "86400"
+
+# Additional env variables if needed (list of {name, value})
+extraEnv: []
+
+# Resource requests/limits for the frontend container
+resources:
+  requests:
+    memory: "512Mi"
+    cpu: "250m"
+  limits:
+    memory: "1Gi"
+    cpu: "500m"
+
+# Optional ingress configuration
+ingress:
+  enabled: true
+  host: "{{ .Values.host }}.{{ .Values.global.domain }}"
+  tlsSecret: public.{{ .Values.host }}.{{ .Values.global.domain }}-cert
+  public:
+    enableCors: true
+  private:
+    enableCors: true
+    whitelistSourceRange: "" # e.g. "xxx.xx.xxx.xxx/32"
+    tlsSecret: "private.{{ .Values.host }}.{{ .Values.global.domain }}-cert"
+    host: ""


### PR DESCRIPTION
## Summary

This PR fixes the MemoryPressure issue affecting `vna-betanet-1` namespace - the same issue that was fixed for testnet in PR #191.

### Problem

Betanet pods are experiencing the same MemoryPressure evictions and 503 errors that affected testnet, because:
- No Kubernetes resource limits were configured for betanet
- The CI/CD pipeline only deployed to testnet

### Solution

| Change | File | Description |
|--------|------|-------------|
| Add betanet config | `charts/values-betanet.yaml` | Betanet environment with same memory limits (512Mi/1Gi) |
| Deploy to betanet | `.github/workflows/dev-release.yml` | Auto-deploy to both testnet and betanet on release |
| Manual deploy workflow | `.github/workflows/manual-deploy.yml` | On-demand deployment to any environment |

### Resource Limits Applied

```yaml
resources:
  requests:
    memory: "512Mi"
    cpu: "250m"
  limits:
    memory: "1Gi"
    cpu: "500m"
```

### Test Plan

1. Merge this PR
2. Run the manual deploy workflow targeting `betanet` to immediately fix the issue
3. Verify pods start successfully with resource limits
4. Monitor memory usage stays within limits
5. Confirm no more MemoryPressure evictions

### Note

The `verana-indexer` repo may have a similar issue - its resource limits are commented out with a FIXME note. Consider applying the same fix there.

Related: PR #191 (testnet fix)