### PR TITLE
fix: text alignment in Featured Services cards

### DIFF
--- a/app/ui/common/featured-services.tsx
+++ b/app/ui/common/featured-services.tsx
@@ -17,16 +17,16 @@ export default function FeaturedServices({ isWalletConnected }: FeaturedServices
                 {links
                     .filter((link) => link.featuredService === true)
                     .map((link, idx: number) => (
-                    <div key={`FeaturedServices-${idx}`} className="bg-white dark:bg-surface rounded-xl border border-neutral-20 dark:border-neutral-70 overflow-hidden hover:shadow-lg transition-shadow duration-200">
-                        <div className="p-6">
+                    <div key={`FeaturedServices-${idx}`} className="bg-white dark:bg-surface rounded-xl border border-neutral-20 dark:border-neutral-70 overflow-hidden hover:shadow-lg transition-shadow duration-200 flex flex-col h-full">
+                        <div className="p-6 flex flex-col h-full">
                             <div className="flex items-center mb-4">
                                 <div className={`w-10 h-10 rounded-lg flex items-center justify-center mr-3 ${link.iconClass}`}>
                                     <FontAwesomeIcon icon={link.icon} className={link.iconClass}/>
                                 </div>
                                 <h4 className="text-lg font-semibold text-gray-900 dark:text-white">{link.name}</h4>
                             </div>
-                            <p className="text-gray-600 dark:text-gray-400 mb-4">{link.description}</p>
-                            <div className="flex items-center justify-between">
+                            <p className="text-gray-600 dark:text-gray-400">{link.description}</p>
+                            <div className="flex items-center justify-between mt-auto pt-4">
                                 { (isWalletConnected || link.availableOffline) ? (
                                 <span className="text-sm text-success-600 dark:text-success-400">{resolveTranslatable({key: 'featuredservices.available'}, translate)}</span>
                                 ) : (


### PR DESCRIPTION
Fixes the alignment issue where "Available now" and "Explore" weren't aligned across cards when descriptions had different lengths.

Added flexbox with `mt-auto` to push the bottom section down consistently.

Closes #150