### PR TITLE
fix: handle null trustUnitPrice and locale-formatted numbers in USD conversion

### DIFF
--- a/app/account/action.tsx
+++ b/app/account/action.tsx
@@ -31,7 +31,7 @@ export default function TdActionPage({ action, setActiveActionId, onRefresh, dat
   const claimableInterests = (data as AccountData).claimableInterests?? undefined;
   const available = claimableInterests ? true : false;
   const trustUnitPrice = useTrustDepositParams().trustUnitPrice;
-  const conversionFactorUSDfromVNA = 1_000_000 / Number(trustUnitPrice);
+  const conversionFactorUSDfromVNA = trustUnitPrice ? 1_000_000 / Number(trustUnitPrice) : 0;
 
   const actionCardYield: ActionCardProps = {
     available,

--- a/app/ui/common/card-view.tsx
+++ b/app/ui/common/card-view.tsx
@@ -18,7 +18,7 @@ type CardViewProps<T> = {
 export default function CardView<T>({ field, data, largeTexts }: CardViewProps<T>) {
     const value = String(data[field.name]);
     const trustUnitPrice = useTrustDepositParams().trustUnitPrice;
-    const conversionFactorUSDfromVNA = 1_000_000 / Number(trustUnitPrice);
+    const conversionFactorUSDfromVNA = trustUnitPrice ? 1_000_000 / Number(trustUnitPrice) : 0;
     const valueUSD = field.usdValue ? formatUSDfromUVNA(value.split('VNA')[0], conversionFactorUSDfromVNA) : null;
     const iconWrapperClass = field.iconClass ?? '';
     const iconColorClass = field.iconColorClass ?? field.iconClass ?? '';

--- a/app/util/util.ts
+++ b/app/util/util.ts
@@ -30,7 +30,15 @@ export function formatUSDfromUVNA(
   conversionFactorUSDfromVNA: number
 ): string {
   if (!amount) return ''
-  const usd = Number(amount) * conversionFactorUSDfromVNA
+  if (!Number.isFinite(conversionFactorUSDfromVNA) || conversionFactorUSDfromVNA <= 0) return ''
+
+  // Clean locale-formatted number (remove thousands separators and whitespace)
+  const cleanAmount = amount.trim().replace(/[^\d.,-]/g, '').replace(/,/g, '');
+  const numericAmount = parseFloat(cleanAmount);
+
+  if (!Number.isFinite(numericAmount)) return ''
+
+  const usd = numericAmount * conversionFactorUSDfromVNA
 
   return ( '≈ $' +
     usd.toLocaleString(undefined, {


### PR DESCRIPTION
## Summary
- Fixes NaN display in Account page when `trustUnitPrice` is null or unavailable
- Fixes locale-formatted number parsing (e.g., "3,642.655174" with commas)

## Root Cause
Two issues were causing `$NaN USD` display:

1. **Null trustUnitPrice**: When `trustUnitPrice` is `null`, `Number(null) = 0`, causing division by zero → `Infinity`/`NaN`

2. **Locale-formatted parsing**: The balance is formatted with `toLocaleString()` which adds commas (e.g., "3,642.655174 VNA"). When extracting the numeric part, `Number("3,642.655174")` returns `NaN` because JavaScript's `Number()` doesn't parse locale-formatted strings.

## Changes

### `app/util/util.ts`
- Added guard for invalid conversion factors (NaN, Infinity, ≤ 0)
- Added cleaning of locale-formatted numbers (removes commas, whitespace) before parsing
- Added validation for parsed numeric amount

### `app/ui/common/card-view.tsx`
- Safe fallback to 0 when `trustUnitPrice` is null

### `app/account/action.tsx`
- Same safe fallback as card-view.tsx

## Test Plan
- [x] Verified build passes
- [x] Verified lint passes
- [x] Manual testing confirms USD displays correctly when trustUnitPrice is available
- [x] Manual testing confirms empty string (not NaN) when trustUnitPrice is unavailable

Closes #205