### PR TITLE
feat: register Verana in WalletConnect Cloud / Reown with projectId and metadata

### DIFF
--- a/app/providers/verana-chain-provider.tsx
+++ b/app/providers/verana-chain-provider.tsx
@@ -14,23 +14,23 @@ export default function RootLayout({ children }: { children: React.ReactNode; })
   const customChains = [veranaChain];
   const assetLists = [{ chain_name: veranaChain.chain_name, assets: [veranaAssets] }];
   const duration = Number(env('NEXT_PUBLIC_SESSION_LIFETIME_SECONDS') || process.env.NEXT_PUBLIC_SESSION_LIFETIME_SECONDS) * 1000;
-                      
+
   return (
       <ChainProvider
-          sessionOptions={{ duration }}          
+          sessionOptions={{ duration }}
           throwErrors= {true}
           chains={customChains}
           assetLists={assetLists}
           wallets={wallets}
           walletConnectOptions={{
             signClient: {
-              projectId: "a8510432ebb71e6948cfd6cde54b70f7",
+              projectId: 'e09f8de2a0b30d2e2ee9d061afb2667b',
               relayUrl: "wss://relay.walletconnect.org",
               metadata: {
-                name: 'Cosmos Kit dApp',
-                description: 'Cosmos Kit dApp built by Create Cosmos App',
-                url: "https://docs.hyperweb.io/cosmos-kit/",
-                icons: [],
+                name: 'Verana',
+                description: 'Verana dashboard for managing and joining digital trust Ecosystems.',
+                url: 'https://verana.io',
+                icons: ['https://verana.io/logo.svg'],
               },
             },
           }}


### PR DESCRIPTION
## Summary
- Registered Verana as a project on WalletConnect Cloud (Reown) and obtained a dedicated projectId
- Replaced the generic "Create Cosmos App" template projectId and metadata in `walletConnectOptions` with Verana branding
- Mobile wallets (Keplr Mobile, Cosmostation, Leap, etc.) now display "Verana" with the correct logo when connecting via QR/deep link

Closes #247