### PR TITLE
feat: include Verana testnet in Cosmos Chain Registry (#253)

### DIFF
--- a/app/config/veranaChain.client.ts
+++ b/app/config/veranaChain.client.ts
@@ -2,7 +2,11 @@
 
 import { Asset } from '@chain-registry/types';
 
-export const veranaChainEnv = {
+// Once Verana testnet is in the official chain-registry npm package
+// (see https://github.com/cosmos/chain-registry/pull/7544), replace with:
+//   import { chain as veranaChainBase } from 'chain-registry/testnet/veranatestnet';
+//   import { assets as veranaAssetList } from 'chain-registry/testnet/veranatestnet';
+export const veranaChainBase = {
   chain_type: 'cosmos',
   chain_name: process.env.NEXT_PUBLIC_VERANA_CHAIN_NAME!,
   pretty_name: process.env.NEXT_PUBLIC_VERANA_CHAIN_NAME!,
@@ -10,16 +14,14 @@ export const veranaChainEnv = {
   apis: {
     rpc: [{ address: process.env.NEXT_PUBLIC_VERANA_RPC_ENDPOINT!, provider: 'verana' }],
     rest: [{ address: process.env.NEXT_PUBLIC_VERANA_REST_ENDPOINT!, provider: 'verana' }],
-
-    },
+  },
   status: 'live',
   network_type: 'testnet',
-  bech32_prefix: "verana",
-  slip44:  118,
+  bech32_prefix: 'verana',
+  slip44: 118,
+  key_algos: ['secp256k1'],
   staking: {
-    staking_tokens: [
-      { denom: "uvna" }
-    ]
+    staking_tokens: [{ denom: 'uvna' }],
   },
   fees: {
     fee_tokens: [
@@ -34,23 +36,22 @@ export const veranaChainEnv = {
   },
   explorers: [
     {
-      kind: 'veranaexplorer',
+      kind: 'Verana Explorer',
       url: 'https://explorer.testnet.verana.network',
-      tx_page: 'https://explorer.mychain.org/tx/${txHash}',
-    },  
- ],
-
+      tx_page: 'https://explorer.testnet.verana.network/tx/${txHash}',
+    },
+  ],
 };
 
 export const veranaAssets: Asset = {
-    description: "Verana Token",
-    type_asset: 'unknown',
-    base: 'uvna',
-    name: 'VeranaToken',
-    display: 'VNA',
-    symbol: 'VNA',
-    denom_units: [
-      { denom: "uvna", exponent: 0 },
-      { denom: "VNA",  exponent: 6 }
-    ]
+  description: 'The native staking and governance token of the Verana testnet.',
+  type_asset: 'sdk.coin',
+  base: 'uvna',
+  name: 'Verana Token',
+  display: 'VNA',
+  symbol: 'VNA',
+  denom_units: [
+    { denom: 'uvna', exponent: 0 },
+    { denom: 'VNA', exponent: 6 },
+  ],
 };

--- a/app/hooks/useVeranaChain.ts
+++ b/app/hooks/useVeranaChain.ts
@@ -2,10 +2,9 @@
 
 import { Chain } from '@chain-registry/types';
 import { env } from 'next-runtime-env';
-import { veranaChainEnv } from '@/config/veranaChain.client';
+import { veranaChainBase } from '@/config/veranaChain.client';
 
 export function useVeranaChain() {
-
     const chainName = env('NEXT_PUBLIC_VERANA_CHAIN_NAME');
     const chainId = env('NEXT_PUBLIC_VERANA_CHAIN_ID');
     const rpc = env('NEXT_PUBLIC_VERANA_RPC_ENDPOINT');
@@ -13,15 +12,16 @@ export function useVeranaChain() {
 
     if (chainName && chainId && rpc && rest) {
         return {
-                ...veranaChainEnv,
-                chain_name: chainName,
-                pretty_name: chainName,
-                chain_id: chainId,
-                apis: {
-                rpc: [{ address:  rpc, provider: 'verana' }],
-                rest: [{ address:  rest, provider: 'verana' }],
-                },
+            ...veranaChainBase,
+            chain_name: chainName,
+            pretty_name: chainName,
+            chain_id: chainId,
+            apis: {
+                rpc: [{ address: rpc, provider: 'verana' }],
+                rest: [{ address: rest, provider: 'verana' }],
+            },
         } as Chain;
     }
-    else return veranaChainEnv as Chain;
+
+    return veranaChainBase as Chain;
 }


### PR DESCRIPTION
## Summary

- Update `veranaChain.client.ts` and `useVeranaChain.ts` to match the Cosmos Chain Registry schema format
- Fix `type_asset` from `'unknown'` to `'sdk.coin'`
- Fix explorer `tx_page` URL (was pointing to `explorer.mychain.org`)
- Add `key_algos` field
- Rename export `veranaChainEnv` → `veranaChainBase` for future chain-registry npm import

Related: https://github.com/cosmos/chain-registry/pull/7544 (external PR to add Verana testnet to the official Cosmos Chain Registry)

Closes #253

## Changes

- `app/config/veranaChain.client.ts` — config aligned with chain-registry format, export renamed
- `app/hooks/useVeranaChain.ts` — updated import name

## Next steps

Once https://github.com/cosmos/chain-registry/pull/7544 is merged and the `chain-registry` npm package updates, the inline config can be replaced with:
```ts
import { chain as veranaChainBase } from 'chain-registry/testnet/veranatestnet';
```

## Test plan

- [x] TypeScript compiles with 0 errors
- [x] No stale `veranaChainEnv` references in source code
- [ ] Verify wallet connection works on dev server
- [ ] Verify chain name displays correctly in UI