### PR TITLE
fix: [Dashboard] Use formatVNAFromUVNA for Total Locked Trust Deposit

### DIFF
--- a/app/hooks/useDashboardData.ts
+++ b/app/hooks/useDashboardData.ts
@@ -8,6 +8,7 @@ import { DashboardData } from '@/ui/dataview/datasections/dashboard';
 import { resolveTranslatable } from '@/ui/dataview/types';
 import { translate } from '@/i18n/dataview';
 import { ApiErrorResponse } from '@/types/apiErrorResponse';
+import { formatVNAFromUVNA } from '@/util/util';
 
 type MetricsApiResponse = {
   participants: number;
@@ -101,7 +102,7 @@ export function useDashboardData() {
     walletPrettyName: wallet ? wallet.prettyName : null,
     ecosystems: metrics ? Number(metrics.active_trust_registries).toLocaleString() : null,
     schemas: metrics ? Number(metrics.active_schemas).toLocaleString() : null,
-    totalLockedTrustDeposit: metrics ? `${Number(metrics.weight).toLocaleString()} VNA` : null,
+    totalLockedTrustDeposit: metrics ? formatVNAFromUVNA(String(metrics.weight)) : null,
     issuedCredentials: metrics ? Number(metrics.issued).toLocaleString() : null,
     verifiedCredentials: metrics ? Number(metrics.verified).toLocaleString() : null,
   };


### PR DESCRIPTION
The dashboard was displaying the Total Locked Trust Deposit value as raw uVNA (micro-VNA) instead of converting it to VNA first. This made the displayed number way too large and confusing.

This was already fixed in commit 319b14d on the original feature branch, but that commit landed after PR #287 was merged, so it never made it to main.

This cherry-picks that fix — replaces the raw `Number(metrics.weight).toLocaleString()` with `formatVNAFromUVNA()` which properly divides by 10^6 and formats the result.

Closes #274