### PR TITLE
fix: correct YAML syntax for NEXT_PUBLIC_VERANA_WEBSOCKET in values.yaml

### DIFF
--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -42,7 +42,7 @@ env:
   NEXT_PUBLIC_VERANA_SIGN_DIRECT_MODE: "false"
   NEXT_PUBLIC_SESSION_LIFETIME_SECONDS: "86400"
   NEXT_PUBLIC_LOW_BALANCE_WARN_UVNA: "1000000"
-  NEXT_PUBLIC_VERANA_WEBSOCKET=wss://idx.testnet.verana.network/verana/indexer/v1/events
+  NEXT_PUBLIC_VERANA_WEBSOCKET: "wss://idx.testnet.verana.network/verana/indexer/v1/events"
 
 # Additional env variables if needed (list of {name, value})
 extraEnv: []


### PR DESCRIPTION
Line 45 in `charts/values.yaml` used `=` instead of `:` for the `NEXT_PUBLIC_VERANA_WEBSOCKET` entry, causing `helm package` to fail with:\n\n```\nerror converting YAML to JSON: yaml: line 47: could not find expected ':'\n```\n\nFix: replace `=` with `:` and quote the value for consistency with the other env vars.