### PR TITLE
fix: easy way to match Verana-front image with the chart version

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -21,8 +21,6 @@ This chart deploys the Verana frontend (Next.js) as a Deployment with a Service,
 | --- | --- | --- |
 | `name` | Application name/labels | `verana-frontend` |
 | `replicas` | Deployment replicas | `1` |
-| `image.tag` | Image tag | `{{ .Chart.Version }}` |
-| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `service.type` | Service type | `ClusterIP` |
 | `service.port` | Service port | `3000` |
 | `service.targetPort` | Container port | `3000` |

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
 {{- end }}
       containers:
         - name: {{ .Values.name }}
-          image: veranalabs/verana-front:{{ tpl .Values.image.tag . }}
+          image: {{ .Values.image.repository | default "veranalabs/verana-front" }}:{{ .Values.image.tag | default .Chart.Version }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
 {{- range $key, $value := .Values.env }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -10,7 +10,8 @@ replicas: 1
 # Image configuration
 image:
   pullPolicy: IfNotPresent
-  tag: "{{ .Chart.Version }}" # Kept aligned with chart version for consistency
+  repository: ""
+  tag: ""
 
 # Service configuration
 service:


### PR DESCRIPTION
Currently, this is almost fully supported, including the repository's default value.