### PR TITLE
fix: [Permission Card] ACTIVE badge blue in detail header

### DIFF
--- a/app/ui/common/permission-card.tsx
+++ b/app/ui/common/permission-card.tsx
@@ -152,7 +152,7 @@ export default function PermissionCard({
   const {permissionHistoryList} = usePermissionHistory(permissionId);
   
   const {labelVpState, classVpState} = vpStateColor(selectedNode.permission?.vp_state as VpState, selectedNode.permission?.vp_exp as string, selectedNode.permission?.expire_soon ?? false);
-  const {labelPermState, classPermState} = permStateBadgeClass(selectedNode.permission?.perm_state as PermState, selectedNode.permission?.expire_soon as boolean);
+  const {labelPermState, classPermState} = permStateBadgeClass(selectedNode.permission?.perm_state as PermState, selectedNode.permission?.expire_soon as boolean, "header");
 
   const [activeActionId, setActiveActionId] = useState<string | null>(null);
 

--- a/app/util/util.ts
+++ b/app/util/util.ts
@@ -254,24 +254,27 @@ export function roleLabel(type: string): string {
   }
 }
 
-export function permStateBadgeClass(permState: PermState, expireSoon: boolean) : {labelPermState: string, classPermState: string} {
+export function permStateBadgeClass(permState: PermState, expireSoon: boolean, variant: "tree" | "header" = "tree") : {labelPermState: string, classPermState: string} {
+  const activeClass = variant === "header"
+    ? "bg-blue-100 text-blue-800 dark:bg-blue-900/20 dark:text-blue-400"
+    : "bg-green-100 text-green-800 dark:bg-green-900/20 dark:text-green-300";
   switch (permState) {
     case "REPAID":
-      return { labelPermState: resolveTranslatable({key: "permission.labelpermstate.repaid"}, translate) ?? "REPAID", 
+      return { labelPermState: resolveTranslatable({key: "permission.labelpermstate.repaid"}, translate) ?? "REPAID",
               classPermState: "bg-gray-100 text-red-800 dark:bg-gray-900/20 dark:text-red-300"};
     case "SLASHED":
-      return { labelPermState: resolveTranslatable({key: "permission.labelpermstate.slashed"}, translate) ?? "SLASHED", 
+      return { labelPermState: resolveTranslatable({key: "permission.labelpermstate.slashed"}, translate) ?? "SLASHED",
               classPermState: "bg-red-900 text-red-100 dark:bg-red-300/20 dark:text-red-800"};
     case "FUTURE":
       return { labelPermState: resolveTranslatable({key: "permission.labelpermstate.future"}, translate) ?? "FUTURE",
               classPermState: "bg-green-100 text-green-800 dark:bg-green-900/20 dark:text-green-300"};
     case "ACTIVE":
-      return expireSoon? { labelPermState: resolveTranslatable({key: "permission.labelpermstate.expiresoon"}, translate) ?? "EXPIRE SOON", 
+      return expireSoon? { labelPermState: resolveTranslatable({key: "permission.labelpermstate.expiresoon"}, translate) ?? "EXPIRE SOON",
               classPermState: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/20 dark:text-yellow-300"}
-              : { labelPermState: resolveTranslatable({key: "permission.labelpermstate.active"}, translate) ?? "ACTIVE", 
-              classPermState: "bg-green-100 text-green-800 dark:bg-green-900/20 dark:text-green-300"};
+              : { labelPermState: resolveTranslatable({key: "permission.labelpermstate.active"}, translate) ?? "ACTIVE",
+              classPermState: activeClass};
     case "INACTIVE":
-      return { labelPermState: resolveTranslatable({key: "permission.labelpermstate.inactive"}, translate) ?? "INACTIVE", 
+      return { labelPermState: resolveTranslatable({key: "permission.labelpermstate.inactive"}, translate) ?? "INACTIVE",
               classPermState: "bg-gray-100 text-gray-800 dark:bg-gray-900/20 dark:text-gray-300"};
     default:
       return  { labelPermState: permState, classPermState: "bg-gray-100 text-gray-800 dark:bg-gray-900/20 dark:text-gray-300" };


### PR DESCRIPTION
Closes #359.

Most of the v4 header landed in #364. Only remaining delta: ACTIVE badge in the detail card header was green, spec wants blue.

- `permStateBadgeClass` gets a `variant: "tree" | "header"` param (default `"tree"`, unchanged).
- `permission-card.tsx` passes `"header"` → ACTIVE renders blue.

Tree rows still show ACTIVE in green per spec.