### PR TITLE
fix: [Participants][Pending Tasks] align permission tree node row + lowercase state badge

### DIFF
--- a/app/ui/common/service-identity.tsx
+++ b/app/ui/common/service-identity.tsx
@@ -43,7 +43,7 @@ export default function ServiceIdentity({
       />
       <span className="text-sm font-medium text-gray-900 dark:text-white break-all">{serviceLabel}</span>
       {showFlag ? (
-        <span className="text-sm flex-shrink-0" aria-hidden="true">
+        <span className="inline-flex items-center leading-none text-sm flex-shrink-0" aria-hidden="true">
           {countryCodeToFlag(countryCode)}
         </span>
       ) : null}

--- a/app/ui/common/tree-node-header.tsx
+++ b/app/ui/common/tree-node-header.tsx
@@ -157,7 +157,7 @@ export default function TreeNodeHeader({
             </>
           ) : (
             <>
-              <FontAwesomeIcon icon={node.icon} className={`${node.iconColorClass} flex-shrink-0`} />
+              <FontAwesomeIcon icon={node.icon} className={`${node.iconColorClass} text-sm flex-shrink-0`} />
               <span className="text-sm font-medium text-gray-700 dark:text-gray-300 break-all">{node.name}</span>
             </>
           )
@@ -169,11 +169,11 @@ export default function TreeNodeHeader({
                 e.stopPropagation()
                 onSelect(node.nodeId)
               }}
-              className="cursor-pointer min-w-0"
+              className="cursor-pointer min-w-0 inline-flex items-center"
             >
               <ServiceIdentity did={permission?.did} fallbackName={node.name} />
             </button>
-            <FontAwesomeIcon icon={faCrown} className="text-yellow-500 flex-shrink-0" aria-hidden="true" />
+            <FontAwesomeIcon icon={faCrown} className="text-yellow-500 text-sm flex-shrink-0" aria-hidden="true" />
           </>
         )}
 

--- a/app/util/util.ts
+++ b/app/util/util.ts
@@ -270,52 +270,56 @@ export function roleLabel(type: string): string {
 }
 
 export function permStateBadgeClass(
-  permState: PermState,
+  permState: PermState | undefined,
   expireSoon: boolean,
   variant: 'tree' | 'header' = 'tree'
 ): { labelPermState: string; classPermState: string } {
+  if (!permState) return { labelPermState: '', classPermState: '' }
   const activeClass =
     variant === 'header'
       ? 'bg-blue-100 text-blue-800 dark:bg-blue-900/20 dark:text-blue-400'
       : 'bg-green-100 text-green-800 dark:bg-green-900/20 dark:text-green-300'
-  switch (permState) {
-    case 'REPAID':
-      return {
-        labelPermState: resolveTranslatable({ key: 'permission.labelpermstate.repaid' }, translate) ?? 'REPAID',
-        classPermState: 'bg-gray-100 text-red-800 dark:bg-gray-900/20 dark:text-red-300',
-      }
-    case 'SLASHED':
-      return {
-        labelPermState: resolveTranslatable({ key: 'permission.labelpermstate.slashed' }, translate) ?? 'SLASHED',
-        classPermState: 'bg-red-900 text-red-100 dark:bg-red-300/20 dark:text-red-800',
-      }
-    case 'FUTURE':
-      return {
-        labelPermState: resolveTranslatable({ key: 'permission.labelpermstate.future' }, translate) ?? 'FUTURE',
-        classPermState: 'bg-green-100 text-green-800 dark:bg-green-900/20 dark:text-green-300',
-      }
-    case 'ACTIVE':
-      return expireSoon
-        ? {
-            labelPermState:
-              resolveTranslatable({ key: 'permission.labelpermstate.expiresoon' }, translate) ?? 'EXPIRE SOON',
-            classPermState: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/20 dark:text-yellow-300',
-          }
-        : {
-            labelPermState: resolveTranslatable({ key: 'permission.labelpermstate.active' }, translate) ?? 'ACTIVE',
-            classPermState: activeClass,
-          }
-    case 'INACTIVE':
-      return {
-        labelPermState: resolveTranslatable({ key: 'permission.labelpermstate.inactive' }, translate) ?? 'INACTIVE',
-        classPermState: 'bg-gray-100 text-gray-800 dark:bg-gray-900/20 dark:text-gray-300',
-      }
-    default:
-      return {
-        labelPermState: permState,
-        classPermState: 'bg-gray-100 text-gray-800 dark:bg-gray-900/20 dark:text-gray-300',
-      }
-  }
+  const badge = ((): { labelPermState: string; classPermState: string } => {
+    switch (permState) {
+      case 'REPAID':
+        return {
+          labelPermState: resolveTranslatable({ key: 'permission.labelpermstate.repaid' }, translate) ?? 'REPAID',
+          classPermState: 'bg-gray-100 text-red-800 dark:bg-gray-900/20 dark:text-red-300',
+        }
+      case 'SLASHED':
+        return {
+          labelPermState: resolveTranslatable({ key: 'permission.labelpermstate.slashed' }, translate) ?? 'SLASHED',
+          classPermState: 'bg-red-900 text-red-100 dark:bg-red-300/20 dark:text-red-800',
+        }
+      case 'FUTURE':
+        return {
+          labelPermState: resolveTranslatable({ key: 'permission.labelpermstate.future' }, translate) ?? 'FUTURE',
+          classPermState: 'bg-green-100 text-green-800 dark:bg-green-900/20 dark:text-green-300',
+        }
+      case 'ACTIVE':
+        return expireSoon
+          ? {
+              labelPermState:
+                resolveTranslatable({ key: 'permission.labelpermstate.expiresoon' }, translate) ?? 'EXPIRE SOON',
+              classPermState: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/20 dark:text-yellow-300',
+            }
+          : {
+              labelPermState: resolveTranslatable({ key: 'permission.labelpermstate.active' }, translate) ?? 'ACTIVE',
+              classPermState: activeClass,
+            }
+      case 'INACTIVE':
+        return {
+          labelPermState: resolveTranslatable({ key: 'permission.labelpermstate.inactive' }, translate) ?? 'INACTIVE',
+          classPermState: 'bg-gray-100 text-gray-800 dark:bg-gray-900/20 dark:text-gray-300',
+        }
+      default:
+        return {
+          labelPermState: permState,
+          classPermState: 'bg-gray-100 text-gray-800 dark:bg-gray-900/20 dark:text-gray-300',
+        }
+    }
+  })()
+  return variant === 'tree' ? { ...badge, labelPermState: badge.labelPermState.toLowerCase() } : badge
 }
 
 export function vpStateColor(


### PR DESCRIPTION
The service identity (icon/name/flag/trust) was wrapped in a non-flex button, so it baseline-aligned a few pixels above the crown and status pill. Made that wrapper flex so the whole row centers on one line, and lowercased the tree state badge to match spec v4 (the card detail header stays uppercase).

Closes #358
Closes #360
