### PR TITLE
fix: [Ecosystems] prevent untrusted-card flash on /tr initial load

### DIFF
--- a/app/hooks/useTrustRegistries.ts
+++ b/app/hooks/useTrustRegistries.ts
@@ -18,7 +18,7 @@ export function useTrustRegistries(all: boolean = false, onlyActive: boolean = t
     process.env.NEXT_PUBLIC_VERANA_REST_ENDPOINT_TRUST_REGISTRY
 
   const [trList, setTrList] = useState<TrList[]>([])
-  const [loading, setLoading] = useState(false)
+  const [loading, setLoading] = useState(true)
   const [errorTrList, setError] = useState<string | null>(null)
 
   const fetchTrList = async () => {

--- a/app/providers/api-rest-query-provider-context.tsx
+++ b/app/providers/api-rest-query-provider-context.tsx
@@ -28,6 +28,7 @@ type DiscoverCtxValue = {
 
 type EcosystemsCtxValue = {
   ecosystemsList: TrList[]
+  ecosystemsLoading: boolean
   refetch: () => Promise<void>
   onlyActiveEcosystem: boolean
   setOnlyActiveEcosystem: React.Dispatch<React.SetStateAction<boolean>>
@@ -58,7 +59,11 @@ export function RestQueryProvider({ children }: { children: React.ReactNode }) {
 
   const [onlyActiveEcosystem, setOnlyActiveEcosystem] = useState(true)
   const [ecosystemFilters, setEcosystemFilters] = useState<Record<string, string | boolean>>({})
-  const { trList: ecosystemsList, refetch: refetchEcosystems } = useTrustRegistries(false, onlyActiveEcosystem)
+  const {
+    trList: ecosystemsList,
+    loading: ecosystemsLoading,
+    refetch: refetchEcosystems,
+  } = useTrustRegistries(false, onlyActiveEcosystem)
 
   const [discoverSearch, setDiscoverSearch] = useState<string>('')
   const [discoverPage, setDiscoverPage] = useState<number>(1)
@@ -93,13 +98,14 @@ export function RestQueryProvider({ children }: { children: React.ReactNode }) {
   const ecosystemsValue = useMemo(
     () => ({
       ecosystemsList,
+      ecosystemsLoading,
       refetch: refetchEcosystems,
       onlyActiveEcosystem,
       setOnlyActiveEcosystem,
       ecosystemFilters,
       setEcosystemFilters,
     }),
-    [ecosystemsList, refetchEcosystems, onlyActiveEcosystem, ecosystemFilters]
+    [ecosystemsList, ecosystemsLoading, refetchEcosystems, onlyActiveEcosystem, ecosystemFilters]
   )
 
   const accountValue = useMemo(

--- a/app/tr/page.tsx
+++ b/app/tr/page.tsx
@@ -9,6 +9,7 @@ import { DidEnrichment, fetchDidEnrichment } from '@/lib/resolverClient'
 import { useEcosytemsCtx } from '@/providers/api-rest-query-provider-context'
 import AddTrPage from '@/tr/add/add'
 import EcosystemCard from '@/ui/common/ecosystem-card'
+import EcosystemCardSkeleton from '@/ui/common/ecosystem-card-skeleton'
 import EcosystemsFilterBar, {
   EcosystemsFilterState,
   INITIAL_ECOSYSTEMS_FILTER,
@@ -53,7 +54,10 @@ export default function TrPage() {
   const [addTR, setAddTR] = useState<boolean>(false)
   const [refresh, setRefresh] = useState<boolean>(true)
   const [trListAll, setTrListAll] = useState<boolean>(false)
-  const [enrichments, setEnrichments] = useState<Record<string, DidEnrichment>>({})
+  const [enrichmentState, setEnrichmentState] = useState<{
+    key: string
+    map: Record<string, DidEnrichment>
+  }>({ key: '', map: {} })
 
   useEffect(() => {
     if (!refresh) return
@@ -76,12 +80,15 @@ export default function TrPage() {
     setPage(1)
   }, [filters])
 
-  const didsKey = ecosystemsCtx.ecosystemsList.map((tr) => tr.did).join('|')
+  const didsKey = useMemo(
+    () => ecosystemsCtx.ecosystemsList.map((tr) => tr.did).join('|'),
+    [ecosystemsCtx.ecosystemsList]
+  )
 
   useEffect(() => {
     const dids = didsKey ? didsKey.split('|') : []
     if (dids.length === 0) {
-      setEnrichments({})
+      setEnrichmentState({ key: didsKey, map: {} })
       return
     }
     let cancelled = false
@@ -93,12 +100,15 @@ export default function TrPage() {
           next[dids[idx]] = result.value
         }
       })
-      setEnrichments(next)
+      setEnrichmentState({ key: didsKey, map: next })
     })
     return () => {
       cancelled = true
     }
   }, [didsKey])
+
+  const enrichments = enrichmentState.map
+  const enrichmentsReady = enrichmentState.key === didsKey
 
   const filtered = useMemo(() => {
     return ecosystemsCtx.ecosystemsList.filter((tr) => {
@@ -124,6 +134,10 @@ export default function TrPage() {
   }, [page, pageCount])
 
   const t = (key: string, fallback: string) => resolveTranslatable({ key }, translate) ?? fallback
+
+  const enrichmentGateActive = !filters.showUntrusted
+  const hasEcosystems = ecosystemsCtx.ecosystemsList.length > 0
+  const gridLoading = (ecosystemsCtx.ecosystemsLoading && !hasEcosystems) || (enrichmentGateActive && !enrichmentsReady)
 
   return (
     <>
@@ -151,25 +165,35 @@ export default function TrPage() {
       <EcosystemsFilterBar value={filters} onChange={setFilters} />
 
       <section id="ecosystems-grid" className="mb-8">
-        {pageItems.length === 0 ? (
-          <div className="bg-white dark:bg-surface rounded-xl border border-neutral-20 dark:border-neutral-70 p-8 text-center text-sm text-neutral-70 dark:text-neutral-70">
-            {t('datatable.tr.empty', 'No ecosystems match your filters.')}
-          </div>
-        ) : (
+        {gridLoading ? (
           <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 sm:gap-6">
-            {pageItems.map((tr) => (
-              <EcosystemCard key={tr.id} ecosystem={tr} />
+            {[...Array(PAGE_SIZE)].map((_, i) => (
+              <EcosystemCardSkeleton key={i} />
             ))}
           </div>
-        )}
+        ) : (
+          <>
+            {pageItems.length === 0 ? (
+              <div className="bg-white dark:bg-surface rounded-xl border border-neutral-20 dark:border-neutral-70 p-8 text-center text-sm text-neutral-70 dark:text-neutral-70">
+                {t('datatable.tr.empty', 'No ecosystems match your filters.')}
+              </div>
+            ) : (
+              <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 sm:gap-6">
+                {pageItems.map((tr) => (
+                  <EcosystemCard key={tr.id} ecosystem={tr} />
+                ))}
+              </div>
+            )}
 
-        <EcosystemsPagination
-          page={safePage}
-          pageCount={pageCount}
-          showing={pageItems.length}
-          total={total}
-          onChange={setPage}
-        />
+            <EcosystemsPagination
+              page={safePage}
+              pageCount={pageCount}
+              showing={pageItems.length}
+              total={total}
+              onChange={setPage}
+            />
+          </>
+        )}
       </section>
 
       {addTR && (

--- a/app/ui/common/ecosystem-card-skeleton.tsx
+++ b/app/ui/common/ecosystem-card-skeleton.tsx
@@ -1,4 +1,6 @@
-const CARD_BODY_CLASS = 'grid h-full min-h-[20.25rem] grid-rows-[5rem_3.25rem_1.5rem_1fr] gap-3 p-4 sm:p-6'
+import { CARD_BODY_CLASS } from './ecosystem-card'
+
+const STAT_ROW_COUNT = 5
 
 export default function EcosystemCardSkeleton() {
   return (
@@ -29,7 +31,7 @@ export default function EcosystemCardSkeleton() {
         </div>
 
         <div className="space-y-2">
-          {[...Array(5)].map((_, i) => (
+          {Array.from({ length: STAT_ROW_COUNT }, (_, i) => (
             <div key={i} className="flex items-center justify-between gap-3">
               <div className="skeleton h-4 w-1/2" />
               <div className="skeleton h-4 w-16" />

--- a/app/ui/common/ecosystem-card-skeleton.tsx
+++ b/app/ui/common/ecosystem-card-skeleton.tsx
@@ -1,0 +1,42 @@
+const CARD_BODY_CLASS = 'grid h-full min-h-[20.25rem] grid-rows-[5rem_3.25rem_1.5rem_1fr] gap-3 p-4 sm:p-6'
+
+export default function EcosystemCardSkeleton() {
+  return (
+    <div
+      aria-hidden="true"
+      className="h-full bg-white dark:bg-surface rounded-xl border border-neutral-20 dark:border-neutral-70 overflow-hidden"
+    >
+      <div className={CARD_BODY_CLASS}>
+        <div className="flex items-start space-x-3 overflow-hidden">
+          <div className="skeleton w-12 h-12 rounded-lg flex-shrink-0" />
+          <div className="flex-1 min-w-0 space-y-2">
+            <div className="skeleton h-5 w-3/4" />
+            <div className="skeleton h-3 w-1/2" />
+          </div>
+        </div>
+
+        <div className="flex items-start space-x-2 overflow-hidden">
+          <div className="skeleton w-8 h-8 rounded flex-shrink-0" />
+          <div className="flex-1 min-w-0 space-y-2">
+            <div className="skeleton h-4 w-2/3" />
+            <div className="skeleton h-3 w-1/4" />
+          </div>
+        </div>
+
+        <div className="flex items-start gap-2">
+          <div className="skeleton-badge w-20" />
+          <div className="skeleton-badge w-14" />
+        </div>
+
+        <div className="space-y-2">
+          {[...Array(5)].map((_, i) => (
+            <div key={i} className="flex items-center justify-between gap-3">
+              <div className="skeleton h-4 w-1/2" />
+              <div className="skeleton h-4 w-16" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/ui/common/ecosystem-card.tsx
+++ b/app/ui/common/ecosystem-card.tsx
@@ -14,7 +14,7 @@ import { countryCodeToFlag, formatNumber, formatVNAFromUVNA, roleBadgeClass, sho
 const ECOSYSTEM_ROLES = ['ECOSYSTEM', 'ISSUER_GRANTOR', 'VERIFIER_GRANTOR', 'ISSUER', 'VERIFIER', 'HOLDER'] as const
 type EcosystemRole = (typeof ECOSYSTEM_ROLES)[number]
 
-const CARD_BODY_CLASS = 'grid h-full min-h-[20.25rem] grid-rows-[5rem_3.25rem_1.5rem_1fr] gap-3 p-4 sm:p-6'
+export const CARD_BODY_CLASS = 'grid h-full min-h-[20.25rem] grid-rows-[5rem_3.25rem_1.5rem_1fr] gap-3 p-4 sm:p-6'
 const CARD_HEADER_REGION_CLASS = 'flex min-h-0 min-w-0 items-start space-x-3 overflow-hidden'
 const CARD_ORG_REGION_CLASS = 'flex min-h-0 min-w-0 items-start space-x-2 overflow-hidden'
 const CARD_ROLES_REGION_CLASS = 'flex min-h-0 min-w-0 items-start gap-2 overflow-hidden'


### PR DESCRIPTION
Closes #355

The /tr grid rendered from the ecosystem list before the trust-status enrichment came back. With "Show untrusted" off (the default), untrusted ecosystems showed for a few ms then vanished once the resolver responded - the flash mjfelis reported on the reopen.

The grid now stays behind a skeleton until the async inputs settle, then paints already-filtered:

- `useTrustRegistries` starts `loading=true` (a fetch always runs on mount; `false` made an empty list look settled), surfaced as `ecosystemsLoading` on the ecosystems context.
- `tr/page` tracks enrichment readiness by tagging the result with the DID set it was computed for, so the empty -> populated frame can't slip through unfiltered. Skeleton shows on first load, or while enrichment is pending and "Show untrusted" is off; background refetches keep the existing cards.
- new `EcosystemCardSkeleton` mirrors the card layout so there's no jump on swap.

The other filter checkboxes are synchronous, so the same gate covers them too.
