### PR TITLE
fix: [CI] dev-release fails on missing .npmrc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apk add --no-cache python3 make g++
 RUN corepack enable
 
 # Copy package files
-COPY package.json pnpm-lock.yaml .npmrc ./
+COPY package.json pnpm-lock.yaml ./
 
 # Install dependencies with cache mount for faster rebuilds
 RUN --mount=type=cache,target=/pnpm-store \


### PR DESCRIPTION
PR #377 added `.npmrc` to the Dockerfile COPY but never committed the file, so dev-release Docker builds fail every release.

Drop it. We don't need it: pnpm is pinned via `packageManager` in `package.json`, and the pnpm settings live in `package.json` and `pnpm-lock.yaml` already.

Verified locally with `docker build --target deps .`.

Closes #384