### PR TITLE
fix: handle renamed block-indexed event from indexer

### DIFF
--- a/app/providers/indexer-events-provider.tsx
+++ b/app/providers/indexer-events-provider.tsx
@@ -5,8 +5,8 @@ import React, { createContext, useCallback, useContext, useEffect, useMemo, useR
 import { logger } from '@/lib/logger'
 import { useComponentsVersion } from '@/providers/components-version-provider'
 
-type BlockProcessedEvent = {
-  type: 'block-processed'
+type BlockIndexedEvent = {
+  type: 'block-indexed'
   height: number
   timestamp: string
 }
@@ -74,8 +74,8 @@ export function IndexerEventsProvider({ children }: { children: React.ReactNode 
 
       ws.onmessage = (event) => {
         try {
-          const data = JSON.parse(event.data) as BlockProcessedEvent
-          if (data.type !== 'block-processed') return
+          const data = JSON.parse(event.data) as BlockIndexedEvent
+          if (data.type !== 'block-indexed') return
           latestProcessedHeightRef.current = data.height
           latestProcessedTimestampRef.current = data.timestamp
           setLatestProcessedHeight(data.height)


### PR DESCRIPTION
Closes #388

Indexer renamed its block event type from "block-processed" to "block-indexed". The frontend was still filtering on the old name, so events were dropped and Block height stayed at 0. Updated indexer-events-provider.tsx accordingly.