### PR TITLE
ci: add Discord release notification workflow

### DIFF
--- a/.github/workflows/discord-release-notify.yml
+++ b/.github/workflows/discord-release-notify.yml
@@ -1,0 +1,10 @@
+name: Discord Release Notify
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  notify:
+    uses: 2060-io/organization/.github/workflows/discord-release-notify-call.yml@main
+    secrets: inherit


### PR DESCRIPTION
Closes #386

Tiny caller workflow that fires on `release: published` and delegates to the reusable workflow in `2060-io/organization` (see 2060-io/organization#44). Both dev prereleases from `dev-release.yml` and stable releases from `stable-release.yml` trigger it. Pattern matches the existing `2060-linter-call.yml` call in `ci.yml`.

Needs an org-level secret `DISCORD_UPDATES_WEBHOOK_URL` scoped to this repo for notifications to actually post. The workflow soft-skips with a warning if the secret is missing, so this is safe to merge before the secret exists. Setup steps for @genaris posted on the issue.
