### PR TITLE
fix: validate URL fields are http/https only

### DIFF
--- a/app/msg/actions_hooks/actionTR.ts
+++ b/app/msg/actions_hooks/actionTR.ts
@@ -25,12 +25,12 @@ import { SimulateResult } from '@/msg/util/signAndBroadcastManualAmino'
 import { extractTxHeight, handleSuccess } from '@/msg/util/signerUtil'
 import { useNotification } from '@/providers/notification-provider'
 import { resolveTranslatable } from '@/ui/dataview/types'
-import { isValidUrl } from '@/util/validations'
+import { isValidHttpUrl } from '@/util/validations'
 
 async function calculateSRIHash(
   docUrl: string | undefined
 ): Promise<{ sri: string | undefined; error: string | undefined }> {
-  if (!docUrl || !isValidUrl(docUrl)) return { sri: undefined, error: 'Invalid Document URL' }
+  if (!docUrl || !isValidHttpUrl(docUrl)) return { sri: undefined, error: 'Invalid Document URL' }
   try {
     const res = await fetch(`/api/sri?url=${encodeURIComponent(docUrl)}`)
     if (!res.ok) {

--- a/app/tr/[id]/page.tsx
+++ b/app/tr/[id]/page.tsx
@@ -21,7 +21,7 @@ import { ModalAction } from '@/ui/common/modal-action'
 import ServiceProviderCard from '@/ui/common/service-provider-card'
 import { getLabelByValue } from '@/ui/dataview/datasections/gfd'
 import { resolveTranslatable } from '@/ui/dataview/types'
-import { isValidDID, isValidUrl } from '@/util/validations'
+import { isValidDID, isValidHttpUrl } from '@/util/validations'
 
 import AddCsPage from '../cs/add/add'
 
@@ -170,7 +170,7 @@ export default function TRViewPage() {
   const visibleSchemas = csList.filter((item) => showArchived || !item.archived)
 
   const didIsValid = isValidDID(editDid)
-  const akaIsValid = isValidUrl(editAka)
+  const akaIsValid = isValidHttpUrl(editAka)
   const editIsValid = didIsValid && akaIsValid && (editDid !== dataTR.did || editAka !== dataTR.aka)
 
   function startEdit() {

--- a/app/util/validations.ts
+++ b/app/util/validations.ts
@@ -12,15 +12,6 @@ export function isValidLanguageTag(lang: string): boolean {
   return LANGUAGE_TAG_PATTERN.test(lang)
 }
 
-export function isValidUrl(url: string): boolean {
-  try {
-    new URL(url)
-    return true
-  } catch {
-    return false
-  }
-}
-
 export function isValidHttpUrl(url: string): boolean {
   try {
     const u = new URL(url)
@@ -50,7 +41,7 @@ export function isValidField(field: DataField<any>, value: unknown): boolean {
     case 'DID':
       return typeof value === 'string' && isValidDID(value)
     case 'URL': {
-      if (typeof value !== 'string' || !isValidUrl(value)) return false
+      if (typeof value !== 'string' || !isValidHttpUrl(value)) return false
       if (minLength !== undefined && value.length < minLength) return false
       if (maxLength !== undefined && value.length > maxLength) return false
       return true


### PR DESCRIPTION
Closes #393

`isValidUrl` returned true for anything `new URL()` parsed, so non-http schemes like `javascript:` and `file:` passed on the URL fields. Switched them to the existing `isValidHttpUrl` and dropped the old `isValidUrl`.
