### PR TITLE
fix: [Credential Schema] source JSON schema max size from the chain

### DIFF
--- a/app/lib/trustDepositParams.ts
+++ b/app/lib/trustDepositParams.ts
@@ -9,6 +9,7 @@ export type TrustDepositParams = {
   trustDepositReclaimBurnRate: string | number | null
   trustDepositRate: string | number | null
   credentialSchemaTrustDeposit: string | number | null
+  credentialSchemaSchemaMaxSize: string | number | null
 }
 
 export const trustDepositParamsInitialState: TrustDepositParams = {
@@ -18,6 +19,7 @@ export const trustDepositParamsInitialState: TrustDepositParams = {
   trustDepositReclaimBurnRate: null,
   trustDepositRate: null,
   credentialSchemaTrustDeposit: null,
+  credentialSchemaSchemaMaxSize: null,
 }
 
 type ParamConfigKey = keyof TrustDepositParams
@@ -63,6 +65,12 @@ const configs: ParamConfig[] = [
   {
     key: 'credentialSchemaTrustDeposit',
     responseKey: 'credential_schema_trust_deposit',
+    envKey: 'NEXT_PUBLIC_VERANA_REST_ENDPOINT_CREDENTIAL_SCHEMA',
+    transform: (value) => (value == null ? null : Number(value)),
+  },
+  {
+    key: 'credentialSchemaSchemaMaxSize',
+    responseKey: 'credential_schema_schema_max_size',
     envKey: 'NEXT_PUBLIC_VERANA_REST_ENDPOINT_CREDENTIAL_SCHEMA',
     transform: (value) => (value == null ? null : Number(value)),
   },

--- a/app/msg/actions_hooks/actionCS.ts
+++ b/app/msg/actions_hooks/actionCS.ts
@@ -22,6 +22,7 @@ import { useSendTxDetectingMode } from '@/msg/util/sendTxDetectingMode'
 import { SimulateResult } from '@/msg/util/signAndBroadcastManualAmino'
 import { extractTxHeight, handleSuccess } from '@/msg/util/signerUtil'
 import { useNotification } from '@/providers/notification-provider'
+import { useTrustDepositParams } from '@/providers/trust-deposit-params-context'
 import { resolveTranslatable } from '@/ui/dataview/types'
 import { normalizeJsonSchema, validateJSONSchemaReturn } from '@/util/json_schema_util'
 
@@ -83,6 +84,7 @@ export function useActionCS(onCancel?: () => void, onRefresh?: (id?: string, txH
   const { address, isWalletConnected } = useChain(veranaChain.chain_name)
 
   const { notify } = useNotification()
+  const { credentialSchemaSchemaMaxSize } = useTrustDepositParams()
   const sendTx = useSendTxDetectingMode(veranaChain)
 
   // Prevents parallel broadcasts with the same account (avoids sequence mismatch errors)
@@ -139,7 +141,11 @@ export function useActionCS(onCancel?: () => void, onRefresh?: (id?: string, txH
 
     if (params.msgType === 'MsgCreateCredentialSchema') {
       try {
-        const errorValidate = validateJSONSchemaReturn(params.jsonSchema)
+        const maxSizeBytes =
+          typeof credentialSchemaSchemaMaxSize === 'number' && credentialSchemaSchemaMaxSize > 0
+            ? credentialSchemaSchemaMaxSize
+            : undefined
+        const errorValidate = validateJSONSchemaReturn(params.jsonSchema, maxSizeBytes)
         if (errorValidate !== null) {
           await notify(
             `${resolveTranslatable({ key: 'error.msg.cs.create.schema.json' }, translate)} ${errorValidate}`,

--- a/app/util/json_schema_util.ts
+++ b/app/util/json_schema_util.ts
@@ -42,9 +42,12 @@ export function normalizeJsonSchema(jsonSchema: string): string {
   }
 }
 
-const DefaultCredentialSchemaSchemaMaxSize = 8192 // set your real parameter
+const DEFAULT_CREDENTIAL_SCHEMA_SCHEMA_MAX_SIZE = 8192
 
-export function validateJSONSchema(schemaJSON: string): void {
+export function validateJSONSchema(
+  schemaJSON: string,
+  maxSizeBytes: number = DEFAULT_CREDENTIAL_SCHEMA_SCHEMA_MAX_SIZE
+): void {
   // Reject empty input
   if (!schemaJSON) {
     throw new Error('json schema cannot be empty')
@@ -52,8 +55,8 @@ export function validateJSONSchema(schemaJSON: string): void {
 
   // Enforce max size in bytes (UTF-8), similar to Go's len([]byte(...))
   const byteLength = new TextEncoder().encode(schemaJSON).length
-  if (byteLength > DefaultCredentialSchemaSchemaMaxSize) {
-    throw new Error(`json schema exceeds maximum size of ${DefaultCredentialSchemaSchemaMaxSize} bytes`)
+  if (byteLength > maxSizeBytes) {
+    throw new Error(`json schema exceeds maximum size of ${maxSizeBytes} bytes`)
   }
 
   // Parse JSON
@@ -104,9 +107,9 @@ export function validateJSONSchema(schemaJSON: string): void {
   }
 }
 
-export function validateJSONSchemaReturn(schemaJSON: string): Error | null {
+export function validateJSONSchemaReturn(schemaJSON: string, maxSizeBytes?: number): Error | null {
   try {
-    validateJSONSchema(schemaJSON)
+    validateJSONSchema(schemaJSON, maxSizeBytes)
     return null
   } catch (e) {
     return e instanceof Error ? e : new Error(String(e))


### PR DESCRIPTION
Closes #394

`app/util/json_schema_util.ts` hardcoded the credential-schema byte limit as `const DefaultCredentialSchemaSchemaMaxSize = 8192 // set your real parameter`, so the create-schema validator ignored the chain. That limit is the governance-settable VPR [GLO] global `credential_schema_schema_max_size`, which the credential-schema module already returns from the same `/params` endpoint we read for `credential_schema_trust_deposit`. If governance ever changed it, the frontend would keep validating against the stale baked-in number.

It now comes through the existing params flow and the validator uses the live value, falling back to 8192 when it is missing. The chains return 8192 today so nothing changes for users yet, it just tracks governance from here on.

check-format, check-types and build all clean.
