### PR TITLE
fix: [Ecosystem] show credential issuer DID instead of controller account

### DIFF
--- a/app/lib/resolverClient.ts
+++ b/app/lib/resolverClient.ts
@@ -11,6 +11,7 @@ export interface DidEnrichment {
   countryCode?: string
   organizationAddress?: string
   organizationRegistryId?: string
+  credentialIssuerDid?: string
   evaluatedAtBlock?: number
   expiresAt?: string
   serviceMinAge?: string
@@ -20,6 +21,7 @@ export interface DidEnrichment {
 
 interface ResolverCredential {
   ecsType?: string | null
+  issuedBy?: string | null
   claims?: Record<string, unknown>
 }
 
@@ -90,6 +92,7 @@ function mapResponse(did: string, raw: ResolverFullResult): DidEnrichment {
   const countryCode = pickString(org?.claims, 'countryCode')
   const organizationAddress = pickString(org?.claims, 'address') ?? pickString(org?.claims, 'streetAddress')
   const organizationRegistryId = pickString(org?.claims, 'registryId') ?? pickString(org?.claims, 'registrationNumber')
+  const credentialIssuerDid = typeof org?.issuedBy === 'string' && org.issuedBy.length > 0 ? org.issuedBy : undefined
 
   const hasResolverEvidence =
     credentials.length > 0 ||
@@ -117,6 +120,7 @@ function mapResponse(did: string, raw: ResolverFullResult): DidEnrichment {
     countryCode,
     organizationAddress,
     organizationRegistryId,
+    credentialIssuerDid,
     evaluatedAtBlock: raw.evaluatedAtBlock,
     expiresAt: raw.expiresAt,
   }

--- a/app/tr/[id]/page.tsx
+++ b/app/tr/[id]/page.tsx
@@ -212,7 +212,7 @@ export default function TRViewPage() {
 
       <EcosystemHeader did={dataTR.did} status={headerStatus} />
 
-      <ServiceProviderCard did={dataTR.did} controller={dataTR.controller} />
+      <ServiceProviderCard did={dataTR.did} />
 
       <section className="mb-8">
         <h2 className="text-lg sm:text-xl font-bold text-gray-900 dark:text-white mb-4">{basicInfoLabel}</h2>

--- a/app/ui/common/service-provider-card.tsx
+++ b/app/ui/common/service-provider-card.tsx
@@ -13,7 +13,6 @@ const MONO_VALUE_CLASS = 'text-gray-900 dark:text-white font-mono text-xs sm:tex
 
 export type ServiceProviderCardProps = {
   did: string
-  controller?: string
 }
 
 function countryName(code: string): string {
@@ -25,15 +24,16 @@ function countryName(code: string): string {
   }
 }
 
-export default function ServiceProviderCard({ did, controller }: ServiceProviderCardProps) {
+export default function ServiceProviderCard({ did }: ServiceProviderCardProps) {
   const { data: enrichment } = useDidTrustEnrichment(did)
 
   const orgName = enrichment?.organizationName ?? enrichment?.serviceName
   const countryCode = enrichment?.countryCode
   const address = enrichment?.organizationAddress
   const registryId = enrichment?.organizationRegistryId
+  const credentialIssuer = enrichment?.credentialIssuerDid
 
-  const hasContent = !!orgName || !!countryCode || !!address || !!registryId
+  const hasContent = !!orgName || !!countryCode || !!address || !!registryId || !!credentialIssuer
   if (!hasContent) return null
 
   const sectionLabel =
@@ -94,9 +94,9 @@ export default function ServiceProviderCard({ did, controller }: ServiceProvider
                 </FieldRow>
               ) : null}
 
-              {controller ? (
+              {credentialIssuer ? (
                 <FieldRow label={`${issuerLabel}:`} labelClassName={LABEL_CLASS}>
-                  <p className={MONO_VALUE_CLASS}>{controller}</p>
+                  <p className={MONO_VALUE_CLASS}>{credentialIssuer}</p>
                 </FieldRow>
               ) : null}
             </div>


### PR DESCRIPTION
Closes #407

The "Credential Issuer" on the Ecosystem view was showing the trust registry's `controller`, a `verana1...` account where a DID belongs. The resolver already returns the credential's issuer, we just weren't using it.

Now it shows the ECS-ORG credential's `issuedBy`. The `controller` still shows as "Controller Corporation" in Basic Information, it was only mislabeled in this one spot.
