### PR TITLE
ci: re-enable discord release notifications on stable releases

### DIFF
--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -88,7 +88,7 @@ jobs:
           echo "- verana-front:${{ needs.release-please.outputs.tag_name }}" >> $GITHUB_STEP_SUMMARY
 
   discord-notify:
-    needs: release-please
+    needs: [release-please, docker-release]
     if: needs.release-please.outputs.releases_created == 'true'
     permissions:
       contents: read

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      notify_tag:
+        description: "Release tag to (re)announce on Discord, e.g. v1.2.0"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -12,6 +18,7 @@ permissions:
 
 jobs:
   release-please:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
@@ -79,3 +86,24 @@ jobs:
           echo "Helm Charts" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "- verana-front:${{ needs.release-please.outputs.tag_name }}" >> $GITHUB_STEP_SUMMARY
+
+  discord-notify:
+    needs: release-please
+    if: needs.release-please.outputs.releases_created == 'true'
+    permissions:
+      contents: read
+    uses: 2060-io/organization/.github/workflows/discord-release-notify-call.yml@main
+    with:
+      tag_name: ${{ needs.release-please.outputs.tag_name }}
+    secrets:
+      DISCORD_UPDATES_WEBHOOK_URL: ${{ secrets.DISCORD_UPDATES_WEBHOOK_URL }}
+
+  discord-notify-manual:
+    if: github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+    uses: 2060-io/organization/.github/workflows/discord-release-notify-call.yml@main
+    with:
+      tag_name: ${{ inputs.notify_tag }}
+    secrets:
+      DISCORD_UPDATES_WEBHOOK_URL: ${{ secrets.DISCORD_UPDATES_WEBHOOK_URL }}


### PR DESCRIPTION
This re-lands #409, which I had to pull back out in #411. When #409 merged, the reusable workflow on `2060-io/organization` main still read the `release` event, so the `tag_name` input the caller passes did not exist yet and the call was invalid. `2060-io/organization#46` landed today and makes that workflow tag driven, so the same job works now.

Same change as before, a `discord-release-notify` job in the `Release Please` workflow that runs after release-please when a release is created, passing the tag and the `DISCORD_UPDATES_WEBHOOK_URL` org secret through to the reusable workflow. Stable only, it fires on the next stable release and posts the embed to `#update`.

@mjfelis can you take a look before we let it ride a real release.
