### PR TITLE
fix: truncate EGF document links on mobile table

### DIFF
--- a/app/ui/common/egf-documents-table.tsx
+++ b/app/ui/common/egf-documents-table.tsx
@@ -134,9 +134,10 @@ export default function EgfDocumentsTable({ versions, activeVersion }: EgfDocume
                     href={row.url}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="text-xs sm:text-sm text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 inline-flex items-center gap-1 break-all"
+                    title={row.url}
+                    className="text-xs sm:text-sm text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 inline-flex items-center gap-1 max-w-[12rem] sm:max-w-sm lg:max-w-xl"
                   >
-                    <span>{row.url}</span>
+                    <span className="truncate min-w-0">{row.url}</span>
                     <FontAwesomeIcon icon={faUpRightFromSquare} className="text-xs flex-shrink-0" />
                   </a>
                 </td>


### PR DESCRIPTION
Closes #419

the doc links broke the mobile layout, `break-all` on the URI column let the long DID url stack one letter per line. truncated it with an ellipsis instead and kept the full url in a `title`.
