### PR TITLE
fix: render real service/org logos from resolver claims on cards

### DIFF
--- a/app/lib/resolverClient.test.ts
+++ b/app/lib/resolverClient.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/config/env', () => ({
+  VERANA_REST_ENDPOINT_RESOLVER: 'https://resolver.test/v1',
+}))
+
+import { fetchDidEnrichment, invalidateDid } from '@/lib/resolverClient'
+
+const DID = 'did:web:service.example'
+
+function resolverResponse({ withLogos = true }: { withLogos?: boolean } = {}) {
+  return {
+    did: DID,
+    trustStatus: 'TRUSTED',
+    evaluatedAtBlock: 42,
+    credentials: [
+      {
+        ecsType: 'ECS-SERVICE',
+        issuedBy: DID,
+        claims: {
+          name: 'Acme Portal',
+          description: 'Acme customer portal',
+          ...(withLogos ? { logo: 'https://service.example/logo.png' } : {}),
+          minimumAgeRequired: 0,
+          termsAndConditions: 'https://service.example/terms',
+          privacyPolicy: 'https://service.example/privacy',
+        },
+      },
+      {
+        ecsType: 'ECS-ORG',
+        issuedBy: 'did:web:ecs.example',
+        claims: {
+          name: 'Acme Corp',
+          ...(withLogos ? { logo: 'https://service.example/org-logo.png' } : {}),
+          countryCode: 'BE',
+          address: 'Rue de la Loi 1, 1000 Brussels',
+          registryId: 'BE0123456789',
+        },
+      },
+    ],
+    failedCredentials: [],
+    dereferenceErrors: [],
+  }
+}
+
+afterEach(() => {
+  invalidateDid(DID)
+  vi.unstubAllGlobals()
+})
+
+describe('fetchDidEnrichment', () => {
+  it('extracts service and organization logos from resolver claims', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify(resolverResponse()), { status: 200 }))
+    )
+
+    const enrichment = await fetchDidEnrichment(DID, { force: true })
+
+    expect(enrichment.trustStatus).toBe('TRUSTED')
+    expect(enrichment.serviceName).toBe('Acme Portal')
+    expect(enrichment.serviceLogoUrl).toBe('https://service.example/logo.png')
+    expect(enrichment.organizationName).toBe('Acme Corp')
+    expect(enrichment.organizationLogoUrl).toBe('https://service.example/org-logo.png')
+    expect(enrichment.countryCode).toBe('BE')
+  })
+
+  it('leaves logo fields undefined when the claims carry none', async () => {
+    const body = resolverResponse({ withLogos: false })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify(body), { status: 200 }))
+    )
+
+    const enrichment = await fetchDidEnrichment(DID, { force: true })
+
+    expect(enrichment.serviceLogoUrl).toBeUndefined()
+    expect(enrichment.organizationLogoUrl).toBeUndefined()
+    expect(enrichment.serviceName).toBe('Acme Portal')
+  })
+})

--- a/app/lib/resolverClient.ts
+++ b/app/lib/resolverClient.ts
@@ -7,7 +7,9 @@ export interface DidEnrichment {
   trustStatus: DidTrustState
   serviceName?: string
   serviceDescription?: string
+  serviceLogoUrl?: string
   organizationName?: string
+  organizationLogoUrl?: string
   countryCode?: string
   organizationAddress?: string
   organizationRegistryId?: string
@@ -83,11 +85,13 @@ function mapResponse(did: string, raw: ResolverFullResult): DidEnrichment {
 
   const serviceName = pickString(service?.claims, 'name')
   const serviceDescription = pickString(service?.claims, 'description')
+  const serviceLogoUrl = pickString(service?.claims, 'logo')
   const serviceMinAge = pickStringOrNumber(service?.claims, 'minimumAgeRequired')
   const serviceTermsUrl = pickString(service?.claims, 'termsAndConditions')
   const servicePrivacyUrl = pickString(service?.claims, 'privacyPolicy')
 
   const organizationName = pickString(org?.claims, 'name')
+  const organizationLogoUrl = pickString(org?.claims, 'logo')
   const countryCode = pickString(org?.claims, 'countryCode')
   const organizationAddress = pickString(org?.claims, 'address') ?? pickString(org?.claims, 'streetAddress')
   const organizationRegistryId = pickString(org?.claims, 'registryId') ?? pickString(org?.claims, 'registrationNumber')
@@ -112,10 +116,12 @@ function mapResponse(did: string, raw: ResolverFullResult): DidEnrichment {
     trustStatus,
     serviceName,
     serviceDescription,
+    serviceLogoUrl,
     serviceMinAge,
     serviceTermsUrl,
     servicePrivacyUrl,
     organizationName,
+    organizationLogoUrl,
     countryCode,
     organizationAddress,
     organizationRegistryId,

--- a/app/ui/common/ecosystem-card.tsx
+++ b/app/ui/common/ecosystem-card.tsx
@@ -8,6 +8,7 @@ import { useDidTrustEnrichment } from '@/hooks/useDidTrustEnrichment'
 import { translate } from '@/i18n/dataview'
 import { serviceAvatarUrl, serviceIdenticonUrl } from '@/lib/resolverClient'
 import { trustStateBadge } from '@/lib/trust-state'
+import LogoImage from '@/ui/common/logo-image'
 import { resolveTranslatable } from '@/ui/dataview/types'
 import { countryCodeToFlag, formatNumber, formatVNAFromUVNA, roleBadgeClass, shortenDID } from '@/util/util'
 
@@ -100,12 +101,10 @@ export default function EcosystemCard({ ecosystem }: Props) {
       <div className={`${CARD_BODY_CLASS} ${isArchived ? 'archived-bg' : ''}`}>
         {/* Trust Registry row */}
         <div className={CARD_HEADER_REGION_CLASS}>
-          <img
-            src={serviceIdenticonUrl(ecosystem.did)}
-            alt=""
-            loading="lazy"
-            referrerPolicy="no-referrer"
-            className="w-12 h-12 rounded-lg flex-shrink-0"
+          <LogoImage
+            src={enrichment?.serviceLogoUrl}
+            fallbackSrc={serviceIdenticonUrl(ecosystem.did)}
+            className="w-12 h-12 rounded-lg flex-shrink-0 object-contain"
           />
           <div className="flex-1 min-w-0">
             <div className="flex items-start justify-between gap-2">
@@ -135,12 +134,10 @@ export default function EcosystemCard({ ecosystem }: Props) {
 
         {/* Organization row */}
         <div className={CARD_ORG_REGION_CLASS}>
-          <img
-            src={serviceAvatarUrl(enrichment?.organizationName ?? ecosystem.did)}
-            alt=""
-            loading="lazy"
-            referrerPolicy="no-referrer"
-            className="w-8 h-8 rounded flex-shrink-0"
+          <LogoImage
+            src={enrichment?.organizationLogoUrl}
+            fallbackSrc={serviceAvatarUrl(enrichment?.organizationName ?? ecosystem.did)}
+            className="w-8 h-8 rounded flex-shrink-0 object-contain"
           />
           <div className="flex-1 min-w-0">
             <h4 className="truncate text-sm font-medium text-gray-900 dark:text-white" title={orgName}>

--- a/app/ui/common/ecosystem-header.tsx
+++ b/app/ui/common/ecosystem-header.tsx
@@ -4,6 +4,7 @@ import { faChildReaching } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { useDidTrustEnrichment } from '@/hooks/useDidTrustEnrichment'
 import { serviceAvatarUrl } from '@/lib/resolverClient'
+import LogoImage from '@/ui/common/logo-image'
 import TrustBadge from '@/ui/common/trust-badge'
 
 export type EcosystemStatus = 'ARCHIVED'
@@ -28,12 +29,10 @@ export default function EcosystemHeader({ did, status }: EcosystemHeaderProps) {
       <div className="bg-white dark:bg-surface rounded-xl border border-neutral-20 dark:border-neutral-70 p-6 sm:p-8">
         <div className="flex flex-col sm:flex-row gap-4 sm:gap-6">
           <div className="flex-shrink-0">
-            <img
-              src={serviceAvatarUrl(did)}
-              alt=""
-              loading="lazy"
-              referrerPolicy="no-referrer"
-              className="w-20 h-20 sm:w-24 sm:h-24 rounded-lg"
+            <LogoImage
+              src={enrichment?.serviceLogoUrl}
+              fallbackSrc={serviceAvatarUrl(did)}
+              className="w-20 h-20 sm:w-24 sm:h-24 rounded-lg object-contain"
             />
           </div>
 

--- a/app/ui/common/logo-image.tsx
+++ b/app/ui/common/logo-image.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { useState } from 'react'
+import { DEFAULT_SERVICE_AVATAR } from '@/lib/resolverClient'
+
+type Props = {
+  /** Real logo URL from the ECS credential (logo claim). Optional. */
+  src?: string
+  /** Generated placeholder (dicebear identicon/avatar) used when no real logo exists or it fails to load. */
+  fallbackSrc: string
+  className?: string
+  alt?: string
+}
+
+/**
+ * Renders the credential logo when available, degrading to the generated
+ * placeholder and finally to the bundled default asset when a source fails
+ * to load.
+ */
+export default function LogoImage({ src, fallbackSrc, className, alt = '' }: Props) {
+  const [failedSrcs, setFailedSrcs] = useState<ReadonlySet<string>>(() => new Set())
+
+  const candidates = [src, fallbackSrc, DEFAULT_SERVICE_AVATAR].filter((s): s is string => !!s)
+  const effectiveSrc = candidates.find((c) => !failedSrcs.has(c)) ?? DEFAULT_SERVICE_AVATAR
+
+  return (
+    <img
+      src={effectiveSrc}
+      alt={alt}
+      loading="lazy"
+      referrerPolicy="no-referrer"
+      className={className}
+      onError={() => setFailedSrcs((prev) => new Set(prev).add(effectiveSrc))}
+    />
+  )
+}

--- a/app/ui/common/permission-card.tsx
+++ b/app/ui/common/permission-card.tsx
@@ -19,6 +19,7 @@ import { logger } from '@/lib/logger'
 import { serviceAvatarUrl, serviceIdenticonUrl } from '@/lib/resolverClient'
 import { useIndexerEvents } from '@/providers/indexer-events-provider'
 import { ActionFieldProps } from '@/ui/common/data-view-typed'
+import LogoImage from '@/ui/common/logo-image'
 import PermissionAttribute from '@/ui/common/permission-atrribute'
 import PermissionTimeline from '@/ui/common/permission-timeline'
 import { PermState, RefreshState, TreeNode } from '@/ui/common/permission-tree-types'
@@ -334,12 +335,10 @@ export default function PermissionCard({ selectedNode, path, csTitle, onRefresh 
                 {resolveTranslatable({ key: 'permissioncard.grantedservice.title' }, translate) ?? 'Granted Service'}
               </h3>
               <div className="flex items-start space-x-4">
-                <img
-                  src={serviceIdenticonUrl(did)}
-                  alt=""
-                  loading="lazy"
-                  referrerPolicy="no-referrer"
-                  className="w-16 h-16 rounded-lg flex-shrink-0"
+                <LogoImage
+                  src={enrichment?.serviceLogoUrl}
+                  fallbackSrc={serviceIdenticonUrl(did)}
+                  className="w-16 h-16 rounded-lg flex-shrink-0 object-contain"
                 />
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center space-x-2 mb-2">
@@ -406,12 +405,10 @@ export default function PermissionCard({ selectedNode, path, csTitle, onRefresh 
                 {resolveTranslatable({ key: 'permissioncard.serviceprovider.title' }, translate) ?? 'Service Provider'}
               </h3>
               <div className="flex items-start space-x-3">
-                <img
-                  src={serviceAvatarUrl(did)}
-                  alt=""
-                  loading="lazy"
-                  referrerPolicy="no-referrer"
-                  className="w-6 h-6 rounded flex-shrink-0"
+                <LogoImage
+                  src={enrichment?.organizationLogoUrl}
+                  fallbackSrc={serviceAvatarUrl(did)}
+                  className="w-6 h-6 rounded flex-shrink-0 object-contain"
                 />
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center space-x-2 mb-1">

--- a/app/ui/common/service-identity.tsx
+++ b/app/ui/common/service-identity.tsx
@@ -2,6 +2,7 @@
 
 import { useDidTrustEnrichment } from '@/hooks/useDidTrustEnrichment'
 import { serviceAvatarUrl } from '@/lib/resolverClient'
+import LogoImage from '@/ui/common/logo-image'
 import { countryCodeToFlag, shortenDID } from '@/util/util'
 import TrustBadge from './trust-badge'
 
@@ -34,12 +35,10 @@ export default function ServiceIdentity({
 
   return (
     <span className={`inline-flex items-center gap-x-2 min-w-0 ${className}`}>
-      <img
-        src={serviceAvatarUrl(avatarSeed)}
-        alt=""
-        loading="lazy"
-        referrerPolicy="no-referrer"
-        className={`${avatarSizeClass} rounded flex-shrink-0`}
+      <LogoImage
+        src={enrichment?.serviceLogoUrl}
+        fallbackSrc={serviceAvatarUrl(avatarSeed)}
+        className={`${avatarSizeClass} rounded flex-shrink-0 object-contain`}
       />
       <span className="text-sm font-medium text-gray-900 dark:text-white break-all">{serviceLabel}</span>
       {showFlag ? (

--- a/app/ui/common/service-provider-card.tsx
+++ b/app/ui/common/service-provider-card.tsx
@@ -4,6 +4,7 @@ import { useDidTrustEnrichment } from '@/hooks/useDidTrustEnrichment'
 import { translate } from '@/i18n/dataview'
 import { serviceAvatarUrl } from '@/lib/resolverClient'
 import FieldRow from '@/ui/common/field-row'
+import LogoImage from '@/ui/common/logo-image'
 import TrustBadge from '@/ui/common/trust-badge'
 import { resolveTranslatable } from '@/ui/dataview/types'
 import { countryCodeToFlag } from '@/util/util'
@@ -51,12 +52,10 @@ export default function ServiceProviderCard({ did }: ServiceProviderCardProps) {
       <div className="bg-white dark:bg-surface rounded-xl border border-neutral-20 dark:border-neutral-70 p-4 sm:p-6">
         <div className="flex flex-col sm:flex-row gap-4 sm:gap-6">
           <div className="flex-shrink-0">
-            <img
-              src={serviceAvatarUrl(did)}
-              alt=""
-              loading="lazy"
-              referrerPolicy="no-referrer"
-              className="w-16 h-16 sm:w-20 sm:h-20 rounded-lg"
+            <LogoImage
+              src={enrichment?.organizationLogoUrl}
+              fallbackSrc={serviceAvatarUrl(did)}
+              className="w-16 h-16 sm:w-20 sm:h-20 rounded-lg object-contain"
             />
           </div>
 


### PR DESCRIPTION
## Problem

Service and organization cards never show the real logo from the ECS credentials — every card renders a generated dicebear identicon keyed on the DID/name. Two gaps:

1. The resolver drops the `logo` claim entirely (fixed in verana-labs/verana-resolver#151).
2. The frontend never consumed it: `DidEnrichment` had no logo field, and all five icon-rendering components pointed straight at dicebear placeholders.

## Change

- **`app/lib/resolverClient.ts`** — extract `serviceLogoUrl` (ECS-SERVICE `logo` claim) and `organizationLogoUrl` (ECS-ORG `logo` claim) into `DidEnrichment`.
- **`app/ui/common/logo-image.tsx`** (new) — shared `LogoImage` component with a degradation chain: real credential logo → dicebear placeholder → bundled `/default-service.svg` (so an unreachable dicebear no longer leaves an empty icon either).
- Wired into all five icon sites: `ecosystem-card` (TR + org rows), `permission-card` (Granted Service + Service Provider), `service-identity`, `service-provider-card`, `ecosystem-header`.
- **`app/lib/resolverClient.test.ts`** (new) — regression tests for the logo extraction (present and absent).

## Notes

- Depends on verana-labs/verana-resolver#151 for the resolver to actually emit the `logo` claim; until it deploys, cards keep degrading gracefully to the placeholder exactly as today.

## Testing

- `npm run check-types` — clean.
- `npm test` — 11 files, 221 tests passing (2 new).
- `biome check` — clean on touched files (remaining `useExhaustiveDependencies` warnings in `permission-card.tsx` are pre-existing).