### PR TITLE
fix: language-options API 500 in standalone (Docker) deployments

### DIFF
--- a/app/api/language-options/route.ts
+++ b/app/api/language-options/route.ts
@@ -23,9 +23,6 @@ const { createRequire } = process.getBuiltinModule('node:module')
 const { readFileSync, readdirSync } = process.getBuiltinModule('node:fs')
 const { dirname, join } = process.getBuiltinModule('node:path')
 
-const cldrRequire = createRequire(import.meta.url)
-const CLDR_MAIN = join(dirname(cldrRequire.resolve('cldr-localenames-full/package.json')), 'main')
-
 type LocaleDisplayNames = {
   languages?: Record<string, string>
   territories?: Record<string, string>
@@ -33,28 +30,53 @@ type LocaleDisplayNames = {
 }
 type CldrNamesFile = { main: Record<string, { localeDisplayNames: LocaleDisplayNames }> }
 
-function readDisplayNames(locale: string, kind: keyof LocaleDisplayNames): Record<string, string> {
-  const file = JSON.parse(readFileSync(join(CLDR_MAIN, locale, `${kind}.json`), 'utf8')) as CldrNamesFile
+// All cldr-localenames-full access is lazy: this module MUST NOT touch the
+// filesystem at module scope. The route is force-static (the response is
+// prerendered at build time, where node_modules is complete), but the runtime
+// still loads this module on request; in the standalone/Docker output the CLDR
+// data only exists because next.config.ts outputFileTracingIncludes copies it,
+// and a module-scope crash would turn the prerendered route into a 500.
+type CldrData = {
+  cldrMain: string
+  englishLanguages: Record<string, string>
+  englishTerritories: Record<string, string>
+  englishScripts: Record<string, string>
+  availableLocaleDirs: Set<string>
+  nativeLanguagesCache: Map<string, Record<string, string> | null>
+}
+
+let cldrData: CldrData | null = null
+
+function readDisplayNames(cldrMain: string, locale: string, kind: keyof LocaleDisplayNames): Record<string, string> {
+  const file = JSON.parse(readFileSync(join(cldrMain, locale, `${kind}.json`), 'utf8')) as CldrNamesFile
   return file.main[locale]?.localeDisplayNames[kind] ?? {}
 }
 
-const englishLanguages = readDisplayNames('en', 'languages')
-const englishTerritories = readDisplayNames('en', 'territories')
-const englishScripts = readDisplayNames('en', 'scripts')
+function loadCldrData(): CldrData {
+  if (cldrData) return cldrData
+  const cldrRequire = createRequire(import.meta.url)
+  const cldrMain = join(dirname(cldrRequire.resolve('cldr-localenames-full/package.json')), 'main')
+  cldrData = {
+    cldrMain,
+    englishLanguages: readDisplayNames(cldrMain, 'en', 'languages'),
+    englishTerritories: readDisplayNames(cldrMain, 'en', 'territories'),
+    englishScripts: readDisplayNames(cldrMain, 'en', 'scripts'),
+    availableLocaleDirs: new Set(readdirSync(cldrMain)),
+    nativeLanguagesCache: new Map(),
+  }
+  return cldrData
+}
 
-const availableLocaleDirs = new Set(readdirSync(CLDR_MAIN))
-const nativeLanguagesCache = new Map<string, Record<string, string> | null>()
-
-function nativeLanguages(dir: string): Record<string, string> | null {
-  const cached = nativeLanguagesCache.get(dir)
+function nativeLanguages(cldr: CldrData, dir: string): Record<string, string> | null {
+  const cached = cldr.nativeLanguagesCache.get(dir)
   if (cached !== undefined) return cached
   let result: Record<string, string> | null = null
   try {
-    result = readDisplayNames(dir, 'languages')
+    result = readDisplayNames(cldr.cldrMain, dir, 'languages')
   } catch {
     result = null
   }
-  nativeLanguagesCache.set(dir, result)
+  cldr.nativeLanguagesCache.set(dir, result)
   return result
 }
 
@@ -64,30 +86,30 @@ function capitalizeFirst(s: string): string {
   return chars[0].toUpperCase() + chars.slice(1).join('')
 }
 
-function englishLabel(loc: Intl.Locale): string | undefined {
-  const base = englishLanguages[loc.language] ?? ENGLISH_LANGUAGE_OVERRIDES[loc.language]
+function englishLabel(cldr: CldrData, loc: Intl.Locale): string | undefined {
+  const base = cldr.englishLanguages[loc.language] ?? ENGLISH_LANGUAGE_OVERRIDES[loc.language]
   if (!base) return undefined
 
   const qualifiers: string[] = []
   if (loc.script) {
-    const name = englishScripts[loc.script]
+    const name = cldr.englishScripts[loc.script]
     if (name) qualifiers.push(name)
   }
   if (loc.region) {
-    const name = englishTerritories[loc.region]
+    const name = cldr.englishTerritories[loc.region]
     if (name) qualifiers.push(name)
   }
 
   return qualifiers.length ? `${base} (${qualifiers.join(', ')})` : base
 }
 
-function autonym(loc: Intl.Locale): string | undefined {
+function autonym(cldr: CldrData, loc: Intl.Locale): string | undefined {
   const scriptDir = loc.script ? `${loc.language}-${loc.script}` : undefined
   const candidates = [loc.baseName, scriptDir, loc.language].filter(
-    (dir): dir is string => !!dir && availableLocaleDirs.has(dir)
+    (dir): dir is string => !!dir && cldr.availableLocaleDirs.has(dir)
   )
   for (const dir of candidates) {
-    const languages = nativeLanguages(dir)
+    const languages = nativeLanguages(cldr, dir)
     if (!languages) continue
     const name = languages[loc.baseName] ?? (scriptDir ? languages[scriptDir] : undefined) ?? languages[loc.language]
     if (name) return name
@@ -98,6 +120,7 @@ function autonym(loc: Intl.Locale): string | undefined {
 let cached: LanguageOption[] | null = null
 
 function buildLanguageOptions(): LanguageOption[] {
+  const cldr = loadCldrData()
   const tags = [
     ...new Set([...availableLocalesData.availableLocales.full, ...defaultContentData.defaultContent, ...PINNED_CODES]),
   ].filter((tag) => tag !== UNDETERMINED_LANGUAGE_TAG)
@@ -115,12 +138,12 @@ function buildLanguageOptions(): LanguageOption[] {
       unresolved.push(tag)
       continue
     }
-    const english = englishLabel(loc)
+    const english = englishLabel(cldr, loc)
     if (!english) {
       unresolved.push(tag)
       continue
     }
-    const native = autonym(loc)
+    const native = autonym(cldr, loc)
     const left = native ? capitalizeFirst(native) : undefined
     const label = left && !english.startsWith(left) ? `${left} — ${english} (${tag})` : `${english} (${tag})`
     entries.push({ value: tag, label, sortKey: english })

--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,17 @@ const nextConfig: NextConfig = {
   env: {
     NEXT_PUBLIC_APP_VERSION: version,
   },
+  // /api/language-options reads these CLDR files with dynamic paths at request
+  // time, which output file tracing cannot discover — without this the files
+  // are missing from the standalone (Docker) output and the route 500s.
+  outputFileTracingIncludes: {
+    '/api/language-options': [
+      'node_modules/cldr-localenames-full/package.json',
+      'node_modules/cldr-localenames-full/main/*/languages.json',
+      'node_modules/cldr-localenames-full/main/en/territories.json',
+      'node_modules/cldr-localenames-full/main/en/scripts.json',
+    ],
+  },
   turbopack: {
     resolveAlias: {
       '@codec-proto': '@verana-labs/verana-types/codec', // @verana-labs/verana-types


### PR DESCRIPTION
## Problem

`GET /api/language-options` returns **500** on every deployed environment (confirmed on `https://app.testnet.verana.network/api/language-options`), which breaks the Governance Framework Language combobox ("Could not load languages") when adding a GF document. It works locally, which masked the bug.

## Root cause

Reproduced by running the published `veranalabs/verana-front:v0.14.1` image's standalone output in isolation — identical `ETag: "66fci67lppl"` 500 as production, with:

```
Error: Cannot find module 'cldr-localenames-full/package.json'
Require stack: app/api/language-options/route.ts  { code: 'MODULE_NOT_FOUND' }
```

Chain of events:

1. The route resolved and read `cldr-localenames-full` **at module scope** with dynamic paths (`createRequire().resolve(...)`, `readFileSync(join(CLDR_MAIN, locale, ...))`).
2. Output file tracing cannot discover dynamic-path reads, so the package never lands in `.next/standalone/node_modules` (verified absent in the published image).
3. The route is `force-static` and its body **is** prerendered into the image — but Next 16 (Turbopack) still loads the route module on request, so the module-scope `resolve()` throws before the prerendered body can be served → 500.
4. Locally (`next dev` / repo-rooted `next start`) the full `node_modules` is reachable by walking up from `.next/standalone`, so everything works — the classic local-vs-standalone divergence.

## Fix (belt and suspenders)

- **Lazy CLDR access** — all filesystem access moved out of module scope into a memoized `loadCldrData()` called from `buildLanguageOptions()`. Module load can never crash the route again.
- **`outputFileTracingIncludes`** in `next.config.ts` for the needed CLDR subset (`main/*/languages.json` + English `territories`/`scripts` + `package.json`, ~18 MB of the 59 MB package), so a genuine runtime render also works in the standalone output.

## Verification (isolated standalone run, no reachable parent node_modules)

- Before: first request → `500`, `MODULE_NOT_FOUND` (exact reproduction of production).
- After: first request → `200`, `x-nextjs-cache: HIT`.
- After, with the prerendered body deleted to force a real render: `200`, `x-nextjs-cache: MISS`, 1,120 options — proving the traced CLDR files satisfy the runtime path too.
- `tsc --noEmit` and `biome check` clean; `cldr-localenames-full` confirmed present in `.next/standalone/node_modules` (18 MB).

Needs a release + testnet redeploy to take effect.