### PR TITLE
feat: identifiable, verifiable-only ecosystems on Discover & Join

### DIFF
--- a/app/discover/page.tsx
+++ b/app/discover/page.tsx
@@ -12,18 +12,20 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import Link from 'next/link'
 import { useEffect, useMemo, useState } from 'react'
 import { translate } from '@/i18n/dataview'
+import { DidEnrichment, fetchDidEnrichment, serviceAvatarUrl, serviceIdenticonUrl } from '@/lib/resolverClient'
 import { useDiscoverCtx } from '@/providers/api-rest-query-provider-context'
 import CsCard from '@/ui/common/cs-card'
+import LogoImage from '@/ui/common/logo-image'
 import TitleAndButton from '@/ui/common/title-and-button'
+import TrustBadge from '@/ui/common/trust-badge'
 import { CsList } from '@/ui/datatable/columnslist/cs'
 import { TrList } from '@/ui/datatable/columnslist/tr'
 import { resolveTranslatable } from '@/ui/dataview/types'
-import { formatVNA } from '@/util/util'
+import { countryCodeToFlag, formatVNA, shortenDID } from '@/util/util'
 
 export default function DiscoverJoinPage() {
   const discoverCtx = useDiscoverCtx()
   const [ecosystems, setEcosystems] = useState<TrList[]>()
-  const loading = false
 
   const csByTrId = useMemo(() => {
     const map = new Map<string, CsList[]>()
@@ -39,7 +41,7 @@ export default function DiscoverJoinPage() {
 
   useEffect(() => {
     if (!discoverCtx.discoverList) {
-      setEcosystems([])
+      setEcosystems(undefined)
       return
     }
     setEcosystems(
@@ -50,13 +52,51 @@ export default function DiscoverJoinPage() {
     )
   }, [discoverCtx.discoverList, csByTrId])
 
+  // Ecosystems without credential schemas are never listed.
+  const withSchemas = useMemo(() => ecosystems?.filter((e) => (e.csList?.length ?? 0) > 0), [ecosystems])
+
+  // Trust-resolve every candidate ecosystem DID. An ecosystem is only shown
+  // once its DID resolves as TRUSTED; while its state is unknown (resolution
+  // pending or failed) it stays hidden.
+  const [enrichmentByDid, setEnrichmentByDid] = useState<Record<string, DidEnrichment>>({})
+
+  useEffect(() => {
+    if (!withSchemas) return
+    let cancelled = false
+    const pending = [...new Set(withSchemas.map((e) => e.did).filter(Boolean))].filter((did) => !enrichmentByDid[did])
+    for (const did of pending) {
+      fetchDidEnrichment(did)
+        .catch((): DidEnrichment => ({ did, trustStatus: 'UNRESOLVED' }))
+        .then((enrichment) => {
+          if (cancelled) return
+          setEnrichmentByDid((prev) => (prev[did] ? prev : { ...prev, [did]: enrichment }))
+        })
+    }
+    return () => {
+      cancelled = true
+    }
+  }, [withSchemas, enrichmentByDid])
+
+  const verifiable = useMemo(
+    () => withSchemas?.filter((e) => enrichmentByDid[e.did]?.trustStatus === 'TRUSTED'),
+    [withSchemas, enrichmentByDid]
+  )
+
+  const resolving = useMemo(
+    () => (withSchemas ?? []).some((e) => e.did && !enrichmentByDid[e.did]),
+    [withSchemas, enrichmentByDid]
+  )
+
   const [search, setSearch] = useState(discoverCtx.discoverSearch)
 
   const filtered = useMemo(() => {
     const term = search.trim().toLowerCase()
-    if (!term) return ecosystems
-    return ecosystems?.filter((e) => e.did?.toLowerCase().includes(term))
-  }, [search, ecosystems])
+    if (!term) return verifiable
+    return verifiable?.filter((e) => {
+      const enrichment = enrichmentByDid[e.did]
+      return [e.did, enrichment?.serviceName, enrichment?.organizationName].some((v) => v?.toLowerCase().includes(term))
+    })
+  }, [search, verifiable, enrichmentByDid])
 
   const PAGE_SIZE = 5
   const [page, setPage] = useState(discoverCtx.discoverPage)
@@ -95,6 +135,8 @@ export default function DiscoverJoinPage() {
     })()
   }, [refresh])
 
+  const loading = ecosystems === undefined || (resolving && (filtered?.length ?? 0) === 0)
+
   return (
     <>
       <TitleAndButton title={resolveTranslatable({ key: 'discover.title' }, translate) ?? 'Discover & Join'} />
@@ -118,71 +160,121 @@ export default function DiscoverJoinPage() {
       </section>
 
       <section id="ecosystem-list" className="space-y-6">
-        {loading
-          ? [...Array(3)].map((_, i) => (
-              <div key={i} className="skeleton-card rounded-xl border border-neutral-20 dark:border-neutral-70">
-                <div className="skeleton-title mb-2 w-1/2" />
-                <div className="skeleton-text w-1/3 mb-6" />
+        {loading ? (
+          [...Array(3)].map((_, i) => (
+            <div key={i} className="skeleton-card rounded-xl border border-neutral-20 dark:border-neutral-70">
+              <div className="skeleton-title mb-2 w-1/2" />
+              <div className="skeleton-text w-1/3 mb-6" />
+              <div className="space-y-4">
+                <div className="skeleton-block h-16 rounded-lg" />
+                <div className="skeleton-block h-16 rounded-lg" />
+              </div>
+            </div>
+          ))
+        ) : (filtered?.length ?? 0) === 0 ? (
+          <div className="bg-white dark:bg-surface border border-neutral-20 dark:border-neutral-70 rounded-xl p-8 text-center">
+            <p className="text-sm text-neutral-70 dark:text-neutral-70">
+              {resolveTranslatable({ key: 'discover.empty' }, translate) ?? 'No verifiable ecosystems found.'}
+            </p>
+          </div>
+        ) : (
+          paginated?.map((eco, idx) => {
+            const egfUrl = eco.versions?.find((x) => x.version === eco.active_version)?.documents?.[0]?.url
+            const enrichment = enrichmentByDid[eco.did]
+            const serviceName = enrichment?.serviceName ?? shortenDID(eco.did) ?? eco.did
+            const orgName = enrichment?.organizationName ?? shortenDID(eco.did) ?? eco.did
+            const flag = countryCodeToFlag(enrichment?.countryCode)
+            return (
+              <div
+                key={`${eco.did}-${idx}`}
+                className="bg-white dark:bg-surface border border-neutral-20 dark:border-neutral-70 rounded-xl p-6"
+              >
+                <div className="mb-6">
+                  {/* Ecosystem service identity */}
+                  <div className="flex items-start space-x-3 mb-3">
+                    <LogoImage
+                      src={enrichment?.serviceLogoUrl}
+                      fallbackSrc={serviceIdenticonUrl(eco.did)}
+                      className="w-12 h-12 rounded-lg flex-shrink-0 object-contain"
+                    />
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2">
+                        <h2 className="text-xl font-bold text-gray-900 dark:text-white break-words" title={serviceName}>
+                          {serviceName}
+                        </h2>
+                        <TrustBadge state={enrichment?.trustStatus} size="xl" />
+                      </div>
+                      {enrichment?.serviceDescription ? (
+                        <p
+                          className="text-xs text-neutral-70 dark:text-neutral-70 mt-1 line-clamp-2 break-words"
+                          title={enrichment.serviceDescription}
+                        >
+                          {enrichment.serviceDescription}
+                        </p>
+                      ) : null}
+                    </div>
+                  </div>
+
+                  {/* Controller organization identity */}
+                  <div className="flex items-start space-x-2 mb-4">
+                    <LogoImage
+                      src={enrichment?.organizationLogoUrl}
+                      fallbackSrc={serviceAvatarUrl(enrichment?.organizationName ?? eco.did)}
+                      className="w-8 h-8 rounded flex-shrink-0 object-contain"
+                    />
+                    <div className="flex-1 min-w-0">
+                      <h3 className="truncate text-sm font-medium text-gray-900 dark:text-white" title={orgName}>
+                        {orgName}
+                      </h3>
+                      <span className="text-lg leading-none" aria-hidden="true">
+                        {flag}
+                      </span>
+                    </div>
+                  </div>
+
+                  <div className="flex items-center space-x-4 text-sm text-neutral-70 dark:text-neutral-70 mb-4">
+                    <span>
+                      <FontAwesomeIcon className="mr-1" aria-hidden="true" icon={faFileContract} />
+                      {eco.csList?.length} {resolveTranslatable({ key: 'discover.cs.label' }, translate)}
+                    </span>
+                    <span>
+                      <FontAwesomeIcon className="mr-1" aria-hidden="true" icon={faCoins} />
+                      {resolveTranslatable({ key: 'discover.td.label' }, translate)} {formatVNA(eco.deposit)}
+                    </span>
+                  </div>
+
+                  <div className="flex flex-wrap gap-3">
+                    {egfUrl && (
+                      <Link
+                        href={egfUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center px-4 py-2 bg-primary-50 dark:bg-primary-900/20 text-primary-700 dark:text-primary-300 rounded-lg hover:bg-primary-100 dark:hover:bg-primary-900/30 transition-colors text-sm font-medium"
+                      >
+                        <FontAwesomeIcon className="mr-2" aria-hidden="true" icon={faScaleBalanced} />
+                        {resolveTranslatable({ key: 'discover.btn.egf' }, translate)}
+                      </Link>
+                    )}
+
+                    <Link
+                      href={`/tr/${eco.id}`}
+                      className="inline-flex items-center px-4 py-2 bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300 rounded-lg hover:bg-blue-100 dark:hover:bg-blue-900/30 transition-colors text-sm font-medium"
+                    >
+                      <FontAwesomeIcon className="mr-2" aria-hidden="true" icon={faShieldHalved} />
+                      {resolveTranslatable({ key: 'discover.btn.view' }, translate)}
+                    </Link>
+                  </div>
+                </div>
+
                 <div className="space-y-4">
-                  <div className="skeleton-block h-16 rounded-lg" />
-                  <div className="skeleton-block h-16 rounded-lg" />
+                  {eco.csList?.map((schema) => (
+                    <CsCard key={schema.id} cs={schema} />
+                  ))}
                 </div>
               </div>
-            ))
-          : paginated?.map((eco, idx) => {
-              const egfUrl = eco.versions?.find((x) => x.version === eco.active_version)?.documents?.[0]?.url
-              return (
-                <div
-                  key={eco.did + '-' + idx}
-                  className="bg-white dark:bg-surface border border-neutral-20 dark:border-neutral-70 rounded-xl p-6"
-                >
-                  <div className="mb-6">
-                    <div className="flex items-start justify-between mb-4">
-                      <div>
-                        <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-2 break-all">{eco.did}</h2>
-                        <div className="flex items-center space-x-4 text-sm text-neutral-70 dark:text-neutral-70">
-                          <span>
-                            <FontAwesomeIcon className="mr-1" aria-hidden="true" icon={faFileContract} />
-                            {eco.csList?.length} {resolveTranslatable({ key: 'discover.cs.label' }, translate)}
-                          </span>
-                          <span>
-                            <FontAwesomeIcon className="mr-1" aria-hidden="true" icon={faCoins} />
-                            {resolveTranslatable({ key: 'discover.td.label' }, translate)} {formatVNA(eco.deposit)}
-                          </span>
-                        </div>
-                      </div>
-                    </div>
-                    <div className="flex flex-wrap gap-3">
-                      {egfUrl && (
-                        <Link
-                          href={egfUrl}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="inline-flex items-center px-4 py-2 bg-primary-50 dark:bg-primary-900/20 text-primary-700 dark:text-primary-300 rounded-lg hover:bg-primary-100 dark:hover:bg-primary-900/30 transition-colors text-sm font-medium"
-                        >
-                          <FontAwesomeIcon className="mr-2" aria-hidden="true" icon={faScaleBalanced} />
-                          {resolveTranslatable({ key: 'discover.btn.egf' }, translate)}
-                        </Link>
-                      )}
-
-                      <Link
-                        href={`/tr/${eco.id}`}
-                        className="inline-flex items-center px-4 py-2 bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300 rounded-lg hover:bg-blue-100 dark:hover:bg-blue-900/30 transition-colors text-sm font-medium"
-                      >
-                        <FontAwesomeIcon className="mr-2" aria-hidden="true" icon={faShieldHalved} />
-                        {resolveTranslatable({ key: 'discover.btn.view' }, translate)}
-                      </Link>
-                    </div>
-                  </div>
-
-                  <div className="space-y-4">
-                    {eco.csList?.map((schema) => (
-                      <CsCard key={schema.id} cs={schema} />
-                    ))}
-                  </div>
-                </div>
-              )
-            })}
+            )
+          })
+        )}
       </section>
 
       {filtered && filtered.length > 0 ? (

--- a/app/i18n/dataview/en.json
+++ b/app/i18n/dataview/en.json
@@ -14,7 +14,8 @@
 
   "discover.title": "Discover & Join",
   "discover.description": "Explore, discover and join existing ecosystems.",
-  "discover.search.placeholder": "Search ecosystems by DID...",
+  "discover.search.placeholder": "Search ecosystems by name or DID...",
+  "discover.empty": "No verifiable ecosystems found.",
   "discover.cs.label": "Credential Schemas",
   "discover.td.label": "Trust Deposit:",
   "discover.btn.egf": "EGF",

--- a/app/i18n/dataview/es.json
+++ b/app/i18n/dataview/es.json
@@ -14,7 +14,8 @@
 
   "discover.title": "Descubre y Únete",
   "discover.description": "Explora, descubre y únete a ecosistemas existentes.",
-  "discover.search.placeholder": "Buscar ecosistema por DID...",
+  "discover.search.placeholder": "Buscar ecosistemas por nombre o DID...",
+  "discover.empty": "No se encontraron ecosistemas verificables.",
   "discover.cs.label": "Esquemas de Credenciales",
   "discover.td.label": "Depósito de Confianza:",
   "discover.btn.egf": "EGF",


### PR DESCRIPTION
## Changes to the Discover & Join page (`/discover`)

1. **Each ecosystem is identifiable (service + controller), like on the Ecosystems page.** The card header no longer shows the bare ecosystem DID: it now renders the service identity (logo via `LogoImage` with identicon fallback, name, trust badge, description) and the controller organization row (logo, name, country flag), all sourced from the same trust enrichment (`fetchDidEnrichment`) the Ecosystems page cards use.

2. **Only verifiable ecosystems are listed.** Every candidate DID is trust-resolved at page level; an ecosystem appears only once its DID resolves as `TRUSTED`. While its state is unknown — resolution still pending, or the resolver unreachable — it does **not** appear. Cards therefore appear progressively as resolutions land; skeletons show while nothing has resolved yet, and a proper empty state ("No verifiable ecosystems found.") replaces the previously blank page.

3. **Ecosystems with 0 credential schemas are never listed** (filtered before trust resolution, so no resolver calls are wasted on them).

Extras that follow from (1):

- Search now matches service name and organization name in addition to the DID; placeholder updated accordingly (en/es).
- Pagination operates on the filtered (verifiable, schema-bearing) list, so page counts stay consistent.

Enrichment results are gated per-DID in a map (failures recorded as `UNRESOLVED` so they stay hidden without refetch loops); resolution status is hoisted to the page rather than per-card so hidden ecosystems can't leave gaps in a page slice.

## Testing

- `tsc --noEmit`, `biome check` clean on touched files (the 3 remaining `useExhaustiveDependencies` warnings pre-date this change); vitest suite passing; `next build` compiles.